### PR TITLE
Fix: Deduplicate login error toast and reset isAuthError on re-submit

### DIFF
--- a/src/components/auth/form-login/index.tsx
+++ b/src/components/auth/form-login/index.tsx
@@ -31,11 +31,14 @@ const FormLogin = ({ onRegisterClick, onForgotPasswordClick }: Props) => {
 
   useEffect(() => {
     if (isAuthError) {
-      toast.error("Invalid credentials. Email or password wrong.");
+      toast.error("Invalid credentials. Email or password wrong.", {
+        id: "login-error",
+      });
     }
   }, [isAuthError]);
 
   const onSubmit = (data: LoginSchema) => {
+    if (isAuthError) setIsAuthError(null);
     login(data);
   };
 


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-590

Summary: Fixed the client login error toast behaviour by resetting 
auth error state before each submission and deduplicating toasts 
using a stable toast ID.

Changes:

Frontend:
* reset `isAuthError` to null before each `login()` call to force 
  the useEffect dependency to transition `true → null → true`, 
  ensuring the error toast fires correctly on every failed attempt 
  even without input changes
* added `id: "login-error"` to the toast call to deduplicate and 
  prevent multiple error toasts stacking on repeated Login clicks

Backend:
* no backend changes in this PR

Result:
* error toast now appears consistently on every failed login attempt
* repeated Login clicks with the same invalid credentials no longer 
  stack multiple toasts on screen
* existing behaviour of clearing the error when the user types is 
  untouched and works as before

Checklist:
* Self-reviewed code
* Tested invalid credentials flow locally
* Verified toast deduplication on repeated submissions
* Verified error clears correctly when user modifies input