### PR TITLE
TM-570: Fix Subject auto-selection when changing Grade in Test Papers

### DIFF
--- a/src/app/test-papers/components/form-test-papper-search/index.tsx
+++ b/src/app/test-papers/components/form-test-papper-search/index.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import InputSelect from "@/components/shared/input-select";
 import { Option } from "@/types/shared-types";
-import { FC } from "react";
+import { FC, useEffect, useRef } from "react";
 import { FormProvider, UseFormReturn } from "react-hook-form";
 import { PaperSearchSchema } from "./schema";
 
@@ -31,6 +33,21 @@ const FormTestPaperSearch: FC<Props> = ({
   };
 
   const selectedGrade = testPaperSearchForm.watch("grade");
+  const prevGradeRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (
+      prevGradeRef.current !== null &&
+      prevGradeRef.current !== selectedGrade
+    ) {
+      testPaperSearchForm.setValue("subject", "", {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    }
+
+    prevGradeRef.current = selectedGrade;
+  }, [selectedGrade, testPaperSearchForm]);
 
   return (
     <FormProvider {...testPaperSearchForm}>


### PR DESCRIPTION
## Jira Ticket
https://softvilmedia-team.atlassian.net/browse/TM-570

## Summary

This PR fixes an issue in the Test Papers search form where changing the selected grade automatically selected the first subject from the new subject list.

## Problem

- When a user selected a grade and subject, then changed the grade:
- The subject field was automatically populated with the first subject of the new grade.
- 

## Solution

- Added logic to reset the subject field whenever the grade field changes.
- Ensured subject selection remains empty until the user manually selects a new subject.
- Prevented automatic defaulting to the first available subject.