### PR TITLE
TM-591: Normalize whitespace in Request & Register Tutor forms

### DIFF
--- a/src/app/register-tutor/schema.ts
+++ b/src/app/register-tutor/schema.ts
@@ -1,26 +1,41 @@
 import { z } from "zod";
 
+const normalizeText = (value: unknown) =>
+  typeof value === "string" ? value.trim().replace(/\s+/g, " ") : value;
+
+const trimOnly = (value: unknown) =>
+  typeof value === "string" ? value.trim() : value;
+
 export const step1Schema = z.object({
-  fullName: z
-    .string()
-    .trim()
-    .min(1, "Full Name is required")
-    .regex(/^[A-Za-z\s]+$/, "Full Name can contain letters and spaces only"),
+  fullName: z.preprocess(
+    normalizeText,
+    z
+      .string()
+      .min(1, "Full Name is required")
+      .regex(/^[A-Za-z\s]+$/, "Full Name can contain letters and spaces only"),
+  ),
 
-  email: z
-    .string()
-    .trim()
-    .min(1, "Email is required")
-    .email("Please enter a valid email address"),
+  email: z.preprocess(
+    trimOnly,
+    z
+      .string()
+      .min(1, "Email is required")
+      .email("Please enter a valid email address"),
+  ),
 
-  contactNumber: z
-    .string()
-    .trim()
-    .min(1, "Contact Number is required")
-    .regex(/^\d+$/, "Contact Number must contain numeric values only")
-    .length(10, "Contact Number should be exactly 10 digits"),
+  contactNumber: z.preprocess(
+    trimOnly,
+    z
+      .string()
+      .min(1, "Contact Number is required")
+      .regex(/^\d+$/, "Contact Number must contain numeric values only")
+      .length(10, "Contact Number should be exactly 10 digits"),
+  ),
 
-  dateOfBirth: z.string().trim().min(1, "Date of Birth is required"),
+  dateOfBirth: z.preprocess(
+    trimOnly,
+    z.string().min(1, "Date of Birth is required"),
+  ),
 
   gender: z.string().refine((v) => ["Male", "Female", "Others"].includes(v), {
     message: "Gender is required",
@@ -91,26 +106,37 @@ export const step2Schema = z.object({
 });
 
 export const step3Schema = z.object({
-  teachingSummary: z
-    .string()
-    .trim()
-    .min(1, "Teaching Summary is required")
-    .max(500, "Teaching Summary cannot exceed 500 characters"),
-  studentResults: z
-    .string()
-    .trim()
-    .min(1, "Student Results is required")
-    .max(500, "Student Results cannot exceed 500 characters"),
-  sellingPoints: z
-    .string()
-    .trim()
-    .min(1, "Selling Points is required")
-    .max(500, "Selling Points cannot exceed 500 characters"),
-  academicDetails: z
-    .string()
-    .trim()
-    .min(1, "Academic Details is required")
-    .max(500, "Academic Details cannot exceed 500 characters"),
+  teachingSummary: z.preprocess(
+    normalizeText,
+    z
+      .string()
+      .min(1, "Teaching Summary is required")
+      .max(500, "Teaching Summary cannot exceed 500 characters"),
+  ),
+
+  studentResults: z.preprocess(
+    normalizeText,
+    z
+      .string()
+      .min(1, "Student Results is required")
+      .max(500, "Student Results cannot exceed 500 characters"),
+  ),
+
+  sellingPoints: z.preprocess(
+    normalizeText,
+    z
+      .string()
+      .min(1, "Selling Points is required")
+      .max(500, "Selling Points cannot exceed 500 characters"),
+  ),
+
+  academicDetails: z.preprocess(
+    normalizeText,
+    z
+      .string()
+      .min(1, "Academic Details is required")
+      .max(500, "Academic Details cannot exceed 500 characters"),
+  ),
 });
 
 export const step4Schema = z.object({


### PR DESCRIPTION
## Jira Ticket
https://softvilmedia-team.atlassian.net/browse/TM-591

## Summary

This PR fixes issues where user inputs in Request a Tutor and Register a Tutor forms were not properly normalized. Leading/trailing spaces and multiple spaces between words were being stored as-is, resulting in inconsistent data formatting.

## Problem
Text fields allowed:

- Leading and trailing spaces (e.g., " Tuition Lanka ")
- Multiple spaces between words (e.g., "Tuition Lanka")

.trim() only removed leading/trailing spaces but did not normalize inner spacing.

## Solution
Introduced input normalization using Zod preprocess
Applied:

- .trim() → removes leading/trailing spaces
- .replace(/\s+/g, " ") → collapses multiple spaces into a single space

Ensured normalization happens before validation and submission