### PR TITLE
TM-615: Add Validation to Restrict Name Field to Letters and Spaces Only

### DIFF
--- a/src/components/home-page/form-contact-us/schema.ts
+++ b/src/components/home-page/form-contact-us/schema.ts
@@ -1,13 +1,29 @@
 import { z } from "zod";
 
+const normalizeText = (value: string) => value.trim().replace(/\s+/g, " ");
+
 export const contactUsSchema = z.object({
-  name: z.string().nonempty("Full Name is required"),
+  name: z
+    .string()
+    .trim()
+    .min(1, "Full Name is required")
+    .regex(/^[A-Za-z\s]+$/, {
+      message: "Name can contain letters and spaces only",
+    })
+    .transform(normalizeText),
 
   email: z
     .string()
-    .nonempty("Email is required.")
-    .email({ message: "Invalid email address" }),
-  message: z.string().nonempty("Message is required."),
+    .trim()
+    .min(1, "Email is required.")
+    .email("Invalid email address"),
+
+  message: z
+    .string()
+    .transform(normalizeText)
+    .refine((val) => val.length > 0, {
+      message: "Message is required.",
+    }),
 });
 
 export type ContactUsSchema = z.infer<typeof contactUsSchema>;


### PR DESCRIPTION
## Jira Ticket
https://softvilmedia-team.atlassian.net/browse/TM-615

## Summary

This PR enhances validation for the Contact Us form by restricting the Name field to accept only alphabetic characters and spaces, preventing numeric and alphanumeric inputs.

## Changes
Added .regex() validation to the Name field
Ensured validation runs before transformation to avoid Zod type issues
Standardized error message: “Name can contain letters and spaces only”

## Before
Name field accepted numeric and alphanumeric values (e.g., John123)
Form submission succeeded without validation errors

## After
Name field accepts only letters and spaces (e.g., John Doe)
Invalid inputs are blocked with a clear error message

## Screenshots
<img width="953" height="827" alt="image" src="https://github.com/user-attachments/assets/e97e6f18-64a0-4028-8dab-ef56fb6433c5" />
