### PR TITLE
TM-691: Fix Forgot Password Modal Not Closing After Successful Submission

### DIFF
--- a/src/components/auth/form-forgot-password/index.tsx
+++ b/src/components/auth/form-forgot-password/index.tsx
@@ -8,9 +8,10 @@ import toast from "react-hot-toast";
 
 type Props = {
   onLoginClick: () => void;
+  onSuccess: () => void;
 };
 
-const FormForgotPassword = ({ onLoginClick }: Props) => {
+const FormForgotPassword = ({ onLoginClick, onSuccess }: Props) => {
   const { forgotPassword, isAuthError, setIsAuthError, isLoading } =
     useAuthContext();
 
@@ -26,6 +27,8 @@ const FormForgotPassword = ({ onLoginClick }: Props) => {
     try {
       await forgotPassword(data);
       toast.success("Password reset link sent to your email.");
+      forgotPasswordForm.reset();
+      onSuccess();
     } catch (error: any) {
       const errorMessage =
         error?.message || "Something went wrong. Please try again.";
@@ -44,6 +47,7 @@ const FormForgotPassword = ({ onLoginClick }: Props) => {
             type="email"
           />
         </div>
+
         {isAuthError && (
           <p className="text-red-500 text-xs mt-3 text-center">{isAuthError}</p>
         )}

--- a/src/components/shared/navbar/hooks/useAuthModalState.tsx
+++ b/src/components/shared/navbar/hooks/useAuthModalState.tsx
@@ -45,6 +45,11 @@ const useAuthModalState = (): LogicReturnType => {
     setIsOpen((show) => !show);
   };
 
+  const handleCloseAuthModal = () => {
+    setIsOpen(false);
+    setIsSignUpModalOpen(false);
+  };
+
   const handleOnChangeForm = (formType: FormType) => {
     setCurrentForm(formType);
   };
@@ -60,14 +65,27 @@ const useAuthModalState = (): LogicReturnType => {
             }
           />
         );
+
       case FormType.SignUp:
         return (
           <FormSignUp onLoginClick={() => handleOnChangeForm(FormType.Login)} />
         );
-      default:
+
+      case FormType.ForgotPassword:
         return (
           <FormForgotPassword
             onLoginClick={() => handleOnChangeForm(FormType.Login)}
+            onSuccess={handleCloseAuthModal}
+          />
+        );
+
+      default:
+        return (
+          <FormLogin
+            onRegisterClick={() => handleOnChangeForm(FormType.SignUp)}
+            onForgotPasswordClick={() =>
+              handleOnChangeForm(FormType.ForgotPassword)
+            }
           />
         );
     }
@@ -79,8 +97,10 @@ const useAuthModalState = (): LogicReturnType => {
         return "Login";
       case FormType.SignUp:
         return "Sign Up";
-      default:
+      case FormType.ForgotPassword:
         return "Forgot Password";
+      default:
+        return "Login";
     }
   };
 
@@ -90,8 +110,10 @@ const useAuthModalState = (): LogicReturnType => {
         return "Login to access to your account";
       case FormType.SignUp:
         return "Sign up to create an account";
-      default:
+      case FormType.ForgotPassword:
         return "Please enter your email to reset your password";
+      default:
+        return "Login to access to your account";
     }
   };
 
@@ -101,8 +123,10 @@ const useAuthModalState = (): LogicReturnType => {
         return "/images/auth/login.svg";
       case FormType.SignUp:
         return "/images/auth/signup.svg";
-      default:
+      case FormType.ForgotPassword:
         return "/images/auth/forgotpassword.svg";
+      default:
+        return "/images/auth/login.svg";
     }
   };
 


### PR DESCRIPTION
## Jira Ticket
https://softvilmedia-team.atlassian.net/browse/TM-691

## Summary

This PR resolves an issue where the Forgot Password modal remained open after successfully sending the password reset link, despite showing a success toast.

## Changes

- Added onSuccess callback to FormForgotPassword
- Triggered modal close after successful API response
- Updated modal close handler to reset all relevant modal states (isOpen and isSignUpModalOpen)
- Ensured modal closes without redirecting to Login form

## Before

- Success toast displayed after submitting valid email
- Forgot Password modal remained open

## After

- Success toast is displayed
- Forgot Password modal closes automatically after successful submission
- No unintended redirection to Login form