### PR TITLE
[TM-588] Fix: Correct ZIP/Postal code validation error message in User Profile

### DIFF
--- a/src/app/profile/[id]/components/form-general-information/schema.ts
+++ b/src/app/profile/[id]/components/form-general-information/schema.ts
@@ -43,7 +43,7 @@ export const generalInfoSchema = z.object({
     .string()
     .trim()
     .min(1, "ZIP / Postal code is required")
-    .regex(/^\d{5}(-\d{4})?$/, "ZIP must be 12345 or 12345-6789 format")
+    .regex(/^\d{5}$/, "Zip/Postal code should be exactly 5 digits")
     .optional(),
   address: z.string().min(1, "Address is required").optional(),
   birthday: z


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-588

Summary: Fixed incorrect validation error message for ZIP/Postal 
Code field in the Client Portal User Profile page.

Changes:

Frontend:
* updated ZIP/Postal code regex validation in profile schema
* changed error message to match expected text exactly:
  "Zip/Postal code should be exactly 5 digits"
* validation rule: /^\d{5}$/ — strictly allows exactly 5 digits

File changed:
* src/app/profile/[id]/components/form-general-information/schema.ts

Backend:
* no backend changes in this PR

Root Cause:
* ZIP/Postal code field had incorrect validation message that
  was inconsistent with the required 5-digit only rule

Result:
* error message now correctly displays:
  "Zip/Postal code should be exactly 5 digits"
* validation strictly enforces exactly 5 digits
* no other validation rules affected

Checklist:
* Self-reviewed code
* Tested invalid ZIP code (less than 5 digits)
* Tested invalid ZIP code (more than 5 digits)
* Tested valid ZIP code (exactly 5 digits)
* Verified no other form fields affected