### PR TITLE
[TM-589] Fix: Restrict future date selection in Birthday field on User Profile

### DIFF
--- a/src/app/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/profile/[id]/components/form-general-information/index.tsx
@@ -115,6 +115,7 @@ const FormGeneralInfo: FC<Props> = ({
                 label="Birthday"
                 name="birthday"
                 type="date"
+                max={new Date().toISOString().split("T")[0]}
                 onKeyDown={(e) => e.preventDefault()}
               />
               <InputMultiSelect

--- a/src/app/profile/[id]/components/form-general-information/schema.ts
+++ b/src/app/profile/[id]/components/form-general-information/schema.ts
@@ -55,6 +55,15 @@ export const generalInfoSchema = z.object({
     .refine(
       (date) => {
         if (!date) return true; // Handled by first refine
+        return isBefore(new Date(date), new Date());
+      },
+      {
+        message: "Birthday cannot be a future date",
+      },
+    )
+    .refine(
+      (date) => {
+        if (!date) return true; // Handled by first refine
         const today = new Date();
         const minDate = addYears(today, -18);
         return isBefore(new Date(date), minDate);


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-589

Summary: Fixed the Birthday field in Client Portal User Profile 
to prevent selection and submission of future dates.

Changes:

Frontend:
* added .refine() validation in birthday schema to reject 
  future dates using isBefore() date comparison
* added error message: "Birthday cannot be a future date"
* set max date attribute on birthday date picker input 
  to today's date to disable future dates in the calendar UI

Files changed:
* src/app/profile/[id]/components/form-general-information/schema.ts
* src/app/profile/[id]/components/form-general-information/index.tsx

Backend:
* no backend changes in this PR

Root Cause:
* Birthday date picker had no max date restriction set
* Schema had no validation rule to reject future dates
* Users could select and save any future date as birthday

Result:
* future dates are now disabled in the date picker UI
* form validation rejects future dates on submission
* error message clearly displayed: "Birthday cannot be a future date"
* valid past dates still work correctly

Checklist:
* Self-reviewed code
* Tested selecting a future date — blocked ✅
* Tested selecting today's date
* Tested selecting a past date — allowed ✅
* Verified error message displays correctly
* Verified no other form fields affected