### PR TITLE
fix: Resolve profile settings bugs - Language dropdown and grade-subject clearing (TM-610, TM-622)

### DIFF
--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -148,8 +148,15 @@ const useLogic = (): LogicReturnType => {
   );
 
   // Rechecks and revalidate subject prepopulated data, since the subjects options are fetched asynchronously
+  // IMPORTANT: Only runs once when initial data is loaded, NOT on subsequent subjectsOptions changes
+  const hasInitialSubjectsBeenSet = useRef(false);
+
   useEffect(() => {
-    if (userRawData && size(subjectsOptions) > 0) {
+    if (
+      userRawData &&
+      size(subjectsOptions) > 0 &&
+      !hasInitialSubjectsBeenSet.current
+    ) {
       const { subjects } = userRawData;
 
       generalInfoForm.setValue(
@@ -160,6 +167,8 @@ const useLogic = (): LogicReturnType => {
           )
           .map((subject) => subject.id),
       );
+
+      hasInitialSubjectsBeenSet.current = true;
     }
   }, [userRawData, subjectsOptions, generalInfoForm]);
 

--- a/src/app/profile/[id]/hooks/util.ts
+++ b/src/app/profile/[id]/hooks/util.ts
@@ -257,10 +257,9 @@ export const countryOptions: Option[] = [
 ];
 
 export const languageOptions = [
-  { value: "en", label: "English" },
-  { value: "sp", label: "Spanish" },
-  { value: "fr", label: "French" },
-  { value: "sn", label: "Sinhala" },
+  { value: "sinhala", label: "Sinhala" },
+  { value: "english", label: "English" },
+  { value: "tamil", label: "Tamil" },
 ];
 
 export const timeZoneOptions = [


### PR DESCRIPTION
Ticket:
- TM-610: https://softvilmedia-team.atlassian.net/browse/TM-610
- TM-622: https://softvilmedia-team.atlassian.net/browse/TM-622

Summary:
Fixed language dropdown dummy data and grade removal clearing all subjects in user profile settings.

Changes:

Frontend:
* Removed dummy languages (Spanish, French) from dropdown
* Added Tamil as required language option
* Updated language values: sinhala, english, tamil
* Added hasInitialSubjectsBeenSet ref to prevent subject reset on grade removal
* Modified useEffect to run only once during initial load

Backend:
* No backend changes in this PR

Files Changed:

* src/app/profile/[id]/hooks/util.ts
  - languageOptions: removed Spanish, French
  - languageOptions: added Tamil
  - languageOptions: updated values to sinhala, english, tamil

* src/app/profile/[id]/hooks/useLogic.tsx
  - Added: const hasInitialSubjectsBeenSet = useRef(false);
  - Modified: useEffect condition with && !hasInitialSubjectsBeenSet.current
  - Added: hasInitialSubjectsBeenSet.current = true; after setValue

Root Cause:

TM-610:
* Language dropdown contained dummy test data (Spanish, French)
* Tamil option was missing

TM-622:
* useEffect re-ran on every subjectsOptions change
* Reset subjects based on stale userRawData when grade removed
* Overwrote correct subject filtering logic

Result:
* Language dropdown shows only: Sinhala, English, Tamil
* Grade removal clears only associated subjects
* Subjects for remaining grades preserved
* No layout or functionality broken

Checklist:
* Self-reviewed code
* Verified language dropdown shows only 3 required options
* Verified removing one grade only clears its subjects
* Verified remaining grades' subjects preserved
* Verified no console errors
* No layout or functionality broken