### PR TITLE
fix: required field indicators, border consistency and spacing in Register & Request a Tutor forms (TM-594, TM-595, TM-618)

### DIFF
--- a/src/app/register-tutor/components/AcademicExperience.tsx
+++ b/src/app/register-tutor/components/AcademicExperience.tsx
@@ -87,7 +87,7 @@ const AcademicExperience = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="tutoringLevels">
-            Tutoring Levels *
+            Tutoring Levels <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="tutoringLevels"
@@ -108,7 +108,7 @@ const AcademicExperience = () => {
 
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="preferredLocations">
-            Preferred Locations *
+            Preferred Locations <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="preferredLocations"
@@ -132,7 +132,7 @@ const AcademicExperience = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="tutorType">
-            Tutor Types *
+            Tutor Types <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="tutorType"
@@ -153,7 +153,7 @@ const AcademicExperience = () => {
 
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="highestEducation">
-            Highest Education Level *
+            Highest Education Level <span className="text-red-500">*</span>
           </Label>
           <select
             id="highestEducation"
@@ -182,7 +182,7 @@ const AcademicExperience = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="yearsExperience">
-            Years of Experience *
+            Years of Experience <span className="text-red-500">*</span>
           </Label>
           <Input
             id="yearsExperience"
@@ -200,7 +200,7 @@ const AcademicExperience = () => {
 
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="tutorMediums">
-            Tutor Mediums *
+            Tutor Mediums <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="tutorMediums"
@@ -224,7 +224,7 @@ const AcademicExperience = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="grades">
-            Grades *
+            Grades <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="grades"
@@ -250,7 +250,7 @@ const AcademicExperience = () => {
 
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="subjects">
-            Subjects *
+            Subjects <span className="text-red-500">*</span>
           </Label>
           <Controller
             name="subjects"

--- a/src/app/register-tutor/components/PersonalInfo.tsx
+++ b/src/app/register-tutor/components/PersonalInfo.tsx
@@ -58,7 +58,7 @@ const PersonalInfo = () => {
       {/* Full Name */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="fullName">
-          Full Name *
+          Full Name <span className="text-red-500">*</span>
         </Label>
         <Input
           id="fullName"
@@ -79,7 +79,7 @@ const PersonalInfo = () => {
       {/* Email */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="email">
-          Email *
+          Email <span className="text-red-500">*</span>
         </Label>
         <Input
           id="email"
@@ -101,7 +101,7 @@ const PersonalInfo = () => {
       {/* Contact Number */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="contactNumber">
-          Contact Number *
+          Contact Number <span className="text-red-500">*</span>
         </Label>
         <Input
           id="contactNumber"
@@ -125,7 +125,7 @@ const PersonalInfo = () => {
       {/* Gender */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="gender">
-          Gender *
+          Gender <span className="text-red-500">*</span>
         </Label>
         <select
           id="gender"
@@ -147,7 +147,7 @@ const PersonalInfo = () => {
       {/* Date of Birth */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="dateOfBirth">
-          Date of Birth *
+          Date of Birth <span className="text-red-500">*</span>
         </Label>
         <Input
           id="dateOfBirth"
@@ -170,7 +170,7 @@ const PersonalInfo = () => {
       {/* Age — auto-calculated */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="age">
-          Age *
+          Age <span className="text-red-500">*</span>
         </Label>
         <Input
           id="age"
@@ -192,7 +192,7 @@ const PersonalInfo = () => {
       {/* Nationality */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="nationality">
-          Nationality *
+          Nationality <span className="text-red-500">*</span>
         </Label>
         <select
           id="nationality"
@@ -214,7 +214,7 @@ const PersonalInfo = () => {
       {/* Race */}
       <div className={fieldWrapper}>
         <Label className="text-sm" htmlFor="race">
-          Race *
+          Race <span className="text-red-500">*</span>
         </Label>
         <select
           id="race"

--- a/src/app/register-tutor/components/TermsAndSubmit.tsx
+++ b/src/app/register-tutor/components/TermsAndSubmit.tsx
@@ -16,7 +16,7 @@ const TermsAndSubmit = () => {
     <div className="space-y-6">
       {/* Certificates Upload */}
       <div>
-        <Label className="text-sm mb-2 block">Certificates *</Label>
+        <Label className="text-sm mb-2 block">Certificates <span className="text-red-500">*</span></Label>
         <Controller
           name="certificatesAndQualifications"
           control={control}
@@ -55,7 +55,7 @@ const TermsAndSubmit = () => {
             htmlFor="agreeTerms"
             className="flex flex-col gap-1 text-sm"
           >
-            <span>I agree to the Terms and Conditions *</span>
+            <span>I agree to the Terms and Conditions <span className="text-red-500">*</span></span>
             <span className="text-xs text-muted-foreground">
               I agree to receiving assignment information via SMS and understand
               that rates are subject to negotiation. Admin fees may apply for
@@ -86,7 +86,7 @@ const TermsAndSubmit = () => {
           >
             <span>
               I agree to receiving assignment information regarding new Tuition
-              Assignments *
+              Assignments <span className="text-red-500">*</span>
             </span>
             <span className="text-xs text-muted-foreground">
               By checking this box, you agree to receive SMS and email

--- a/src/app/register-tutor/components/TutorProfile.tsx
+++ b/src/app/register-tutor/components/TutorProfile.tsx
@@ -43,7 +43,7 @@ const TutorProfile = () => {
       {/* Teaching Summary */}
       <div className={fieldWrapper}>
         <Label htmlFor="teachingSummary" className="text-sm mb-1 block">
-          Short Introduction About Yourself *
+          Short Introduction About Yourself <span className="text-red-500">*</span>
         </Label>
         <Textarea
           id="teachingSummary"
@@ -64,7 +64,7 @@ const TutorProfile = () => {
       {/* Academic Details */}
       <div className={fieldWrapper}>
         <Label htmlFor="academicDetails" className="text-sm mb-1 block">
-          Summary of Teaching Experience &amp; Academic Achievements *
+          Summary of Teaching Experience &amp; Academic Achievements <span className="text-red-500">*</span>
         </Label>
         <Textarea
           id="academicDetails"
@@ -85,7 +85,7 @@ const TutorProfile = () => {
       {/* Student Results */}
       <div className={fieldWrapper}>
         <Label htmlFor="studentResults" className="text-sm mb-1 block">
-          Results of Students / Track Record *
+          Results of Students / Track Record <span className="text-red-500">*</span>
         </Label>
         <Textarea
           id="studentResults"
@@ -106,7 +106,7 @@ const TutorProfile = () => {
       {/* Selling Points */}
       <div className={fieldWrapper}>
         <Label htmlFor="sellingPoints" className="text-sm mb-1 block">
-          Other Selling Points as a Tutor *
+          Other Selling Points as a Tutor <span className="text-red-500">*</span>
         </Label>
         <Textarea
           id="sellingPoints"

--- a/src/app/request-for-tutors/create-request/page.tsx
+++ b/src/app/request-for-tutors/create-request/page.tsx
@@ -210,7 +210,7 @@ export default function AddRequestForTutor() {
                 {/* Full Name */}
                 <div className={fieldWrapper}>
                   <Label className="text-sm" htmlFor="name">
-                    Full Name *
+                    Full Name <span className="text-red-500">*</span>
                   </Label>
                   <Input
                     id="name"
@@ -246,7 +246,7 @@ export default function AddRequestForTutor() {
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className={fieldWrapper}>
                     <Label className="text-sm" htmlFor="email">
-                      Email *
+                      Email <span className="text-red-500">*</span>
                     </Label>
                     <Input
                       id="email"
@@ -281,7 +281,7 @@ export default function AddRequestForTutor() {
                   </div>
                   <div className={fieldWrapper}>
                     <Label className="text-sm" htmlFor="phoneNumber">
-                      Contact Number *
+                      Contact Number <span className="text-red-500">*</span>
                     </Label>
                     <Input
                       id="phoneNumber"
@@ -322,50 +322,53 @@ export default function AddRequestForTutor() {
                   </div>
                 </div>
 
-                {/* District */}
-                <div className={fieldWrapper}>
-                  <Label className="text-sm" htmlFor="district">
-                    District *
-                  </Label>
-                  <Controller
-                    control={control}
-                    name="district"
-                    render={({ field }) => (
-                      <DistrictSelect
-                        value={field.value || ""}
-                        onChange={(val) => {
-                          field.onChange(val);
-                          if (val) clearErrors("district");
-                        }}
-                        districts={districts}
-                        hasError={!!errors.district}
-                      />
-                    )}
-                  />
-                  <p className={errorMsg}>{errors.district?.message}</p>
-                </div>
+                {/* District + City – grouped to reduce spacing between them */}
+                <div className="flex flex-col gap-2">
+                  {/* District */}
+                  <div className={fieldWrapper}>
+                    <Label className="text-sm" htmlFor="district">
+                      District <span className="text-red-500">*</span>
+                    </Label>
+                    <Controller
+                      control={control}
+                      name="district"
+                      render={({ field }) => (
+                        <DistrictSelect
+                          value={field.value || ""}
+                          onChange={(val) => {
+                            field.onChange(val);
+                            if (val) clearErrors("district");
+                          }}
+                          districts={districts}
+                          hasError={!!errors.district}
+                        />
+                      )}
+                    />
+                    <p className={errorMsg}>{errors.district?.message}</p>
+                  </div>
 
-                {/* City */}
-                <div className={fieldWrapper}>
-                  <Label className="text-sm" htmlFor="city">
-                    City *
-                  </Label>
-                  <Controller
-                    control={control}
-                    name="city"
-                    render={({ field }) => (
-                      <CitySelect
-                        value={field.value || ""}
-                        district={selectedDistrict || ""}
-                        onChange={(val) => {
-                          field.onChange(val);
-                          if (val) clearErrors("city");
-                        }}
-                        hasError={!!errors.city}
-                      />
-                    )}
-                  />
-                  <p className={errorMsg}>{errors.city?.message}</p>
+                  {/* City */}
+                  <div className={fieldWrapper}>
+                    <Label className="text-sm" htmlFor="city">
+                      City <span className="text-red-500">*</span>
+                    </Label>
+                    <Controller
+                      control={control}
+                      name="city"
+                      render={({ field }) => (
+                        <CitySelect
+                          value={field.value || ""}
+                          district={selectedDistrict || ""}
+                          onChange={(val) => {
+                            field.onChange(val);
+                            if (val) clearErrors("city");
+                          }}
+                          hasError={!!errors.city}
+                        />
+                      )}
+                    />
+                    <p className={errorMsg}>{errors.city?.message}</p>
+                  </div>
                 </div>
               </CardContent>
 
@@ -387,7 +390,7 @@ export default function AddRequestForTutor() {
                 {/* Medium */}
                 <div className={fieldWrapper}>
                   <Label className="text-sm" htmlFor="medium">
-                    Medium *
+                    Medium <span className="text-red-500">*</span>
                   </Label>
                   <select
                     id="medium"
@@ -407,7 +410,7 @@ export default function AddRequestForTutor() {
                 {/* Grade */}
                 <div className={fieldWrapper}>
                   <Label className="text-sm" htmlFor="grade">
-                    Grade *
+                    Grade <span className="text-red-500">*</span>
                   </Label>
                   <select
                     id="grade"
@@ -466,13 +469,13 @@ export default function AddRequestForTutor() {
                         className="text-sm"
                         htmlFor={`subject-${index}`}
                       >
-                        Subject *
+                        Subject <span className="text-red-500">*</span>
                       </Label>
                       <select
                         id={`subject-${index}`}
                         {...register(`tutors.${index}.subject`)}
                         disabled={!selectedGradeId}
-                        className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.subject)} disabled:opacity-50 disabled:cursor-not-allowed`}
+                        className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.subject)} disabled:bg-gray-100 disabled:cursor-not-allowed`}
                       >
                         <option value="" disabled hidden>
                           {selectedGradeId
@@ -497,7 +500,7 @@ export default function AddRequestForTutor() {
                           className="text-sm"
                           htmlFor={`duration-${index}`}
                         >
-                          Duration *
+                          Duration <span className="text-red-500">*</span>
                         </Label>
                         <select
                           id={`duration-${index}`}
@@ -522,7 +525,7 @@ export default function AddRequestForTutor() {
                           className="text-sm"
                           htmlFor={`frequency-${index}`}
                         >
-                          Frequency *
+                          Frequency <span className="text-red-500">*</span>
                         </Label>
                         <select
                           id={`frequency-${index}`}
@@ -548,7 +551,7 @@ export default function AddRequestForTutor() {
                         className="text-sm"
                         htmlFor={`tutorType-${index}`}
                       >
-                        Preferred Tutor Type *
+                        Preferred Tutor Type <span className="text-red-500">*</span>
                       </Label>
                       <select
                         id={`tutorType-${index}`}

--- a/src/components/form-controls/city-select/index.tsx
+++ b/src/components/form-controls/city-select/index.tsx
@@ -155,7 +155,7 @@ export default function CitySelect({
         placeholder={district ? "Search city..." : "Select district first"}
         disabled={!district}
         autoComplete="off"
-        className={`h-11 text-[16px] placeholder:text-gray-500 text-gray-900 ${hasError ? "border-red-500" : "border-gray-300"}`}
+        className={`h-11 text-[16px] placeholder:text-gray-500 text-gray-900 disabled:opacity-100 disabled:bg-gray-100 ${hasError ? "border-red-500" : "border-gray-300"}`}
       />
 
       {showDropdown && (


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-594
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-595
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-618

Summary: Fixed three UI bugs across the "Register a Tutor" and "Request
a Tutor" forms — red required field indicators, inconsistent border color
on City and Subject fields, and excessive spacing between District and City.

Changes:

Frontend:
* TM-594: wrapped all required field asterisks (*) in
  <span className="text-red-500">*</span> across both forms
* TM-595: fixed City field border appearing lighter by overriding
  disabled:opacity-50 with disabled:opacity-100 disabled:bg-gray-100
* TM-595: fixed Subject field border appearing lighter by replacing
  disabled:opacity-50 with disabled:bg-gray-100
* TM-618: reduced excessive spacing between District and City fields
  by grouping them in a flex flex-col gap-2 container

Files changed:
* src/app/register-tutor/components/PersonalInfo.tsx
  - 8 required field labels: added red asterisk span

* src/app/register-tutor/components/AcademicExperience.tsx
  - 8 required field labels: added red asterisk span

* src/app/register-tutor/components/TutorProfile.tsx
  - 4 required field labels: added red asterisk span

* src/app/register-tutor/components/TermsAndSubmit.tsx
  - 3 required field labels: added red asterisk span

* src/app/request-for-tutors/create-request/page.tsx
  - 11 required field labels: added red asterisk span
  - Subject select: disabled:opacity-50 → disabled:bg-gray-100
  - District + City: wrapped in flex flex-col gap-2 to reduce spacing

* src/components/form-controls/city-select/index.tsx
  - City input: added disabled:opacity-100 disabled:bg-gray-100
    to override shadcn Input default disabled:opacity-50

Backend:
* no backend changes in this PR

Root Cause:
* TM-594: asterisk (*) was plain text with no color styling applied
* TM-595: shadcn Input and native select both apply disabled:opacity-50
  causing the border to render at 50% opacity, appearing lighter
* TM-618: District and City were direct children of CardContent (gap-4)
  creating larger than intended spacing between them

Result:
* all required field asterisks display in red across both forms
* City and Subject field borders are visually consistent with other fields
* District and City fields have consistent spacing matching other fields
* no validation, functionality or layout broken

Checklist:
* Self-reviewed code
* Verified red asterisks on all required fields in Register a Tutor form
* Verified red asterisks on all required fields in Request a Tutor form
* Verified City field border consistent with other input fields
* Verified Subject field border consistent when grade not selected
* Verified District-to-City spacing consistent with other field gaps
* Verified no existing validation or functionality broken
