### PR TITLE
fix(TM-618): fix excessive spacing between District and City fields

### DIFF
--- a/src/app/request-for-tutors/create-request/page.tsx
+++ b/src/app/request-for-tutors/create-request/page.tsx
@@ -204,7 +204,9 @@ export default function AddRequestForTutor() {
           <TabsContent value="contact">
             <Card>
               <CardHeader>
-                <CardTitle className="text-base font-medium">Contact Details</CardTitle>
+                <CardTitle className="text-base font-medium">
+                  Contact Details
+                </CardTitle>
               </CardHeader>
               <CardContent className="flex flex-col gap-4">
                 {/* Full Name */}
@@ -323,7 +325,7 @@ export default function AddRequestForTutor() {
                 </div>
 
                 {/* District + City – grouped to reduce spacing between them */}
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-4">
                   {/* District */}
                   <div className={fieldWrapper}>
                     <Label className="text-sm" htmlFor="district">
@@ -344,7 +346,7 @@ export default function AddRequestForTutor() {
                         />
                       )}
                     />
-                    <p className={errorMsg}>{errors.district?.message}</p>
+                    {errors.district?.message && <p className={errorMsg}>{errors.district.message}</p>}
                   </div>
 
                   {/* City */}
@@ -367,7 +369,9 @@ export default function AddRequestForTutor() {
                         />
                       )}
                     />
-                    <p className={errorMsg}>{errors.city?.message}</p>
+                    {errors.city?.message && (
+                      <p className={errorMsg}>{errors.city.message}</p>
+                    )}
                   </div>
                 </div>
               </CardContent>
@@ -384,7 +388,9 @@ export default function AddRequestForTutor() {
           <TabsContent value="tutorDetails">
             <Card>
               <CardHeader>
-                <CardTitle className="text-base font-medium">Tutor Details</CardTitle>
+                <CardTitle className="text-base font-medium">
+                  Tutor Details
+                </CardTitle>
               </CardHeader>
               <CardContent className="flex flex-col gap-4">
                 {/* Medium */}
@@ -465,10 +471,7 @@ export default function AddRequestForTutor() {
 
                     {/* Subject */}
                     <div className={`${fieldWrapper} mb-4`}>
-                      <Label
-                        className="text-sm"
-                        htmlFor={`subject-${index}`}
-                      >
+                      <Label className="text-sm" htmlFor={`subject-${index}`}>
                         Subject <span className="text-red-500">*</span>
                       </Label>
                       <select
@@ -547,11 +550,9 @@ export default function AddRequestForTutor() {
 
                     {/* Preferred Tutor Type */}
                     <div className={`${fieldWrapper} mt-4`}>
-                      <Label
-                        className="text-sm"
-                        htmlFor={`tutorType-${index}`}
-                      >
-                        Preferred Tutor Type <span className="text-red-500">*</span>
+                      <Label className="text-sm" htmlFor={`tutorType-${index}`}>
+                        Preferred Tutor Type{" "}
+                        <span className="text-red-500">*</span>
                       </Label>
                       <select
                         id={`tutorType-${index}`}


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-618

Summary: Fixed excessive spacing between District and City fields in the Request For Tutor form.

Changes:

Frontend:
* Conditionally render District error message so empty space is not reserved when no validation error is present
* Increased gap between District and City wrapper from gap-2 to gap-4 for consistent field spacing

File changed:
* src/app/request-for-tutors/create-request/page.tsx

Backend:
* No backend changes in this PR

Root Cause:
* District error paragraph was always rendered with min-h-[1.25rem] reserved height, creating phantom space between District and City fields even when no validation error existed

Result:
* Spacing between District and City fields is now consistent with other form fields
* District error message still displays correctly when validation fails
* No other form fields affected

Screenshots

<img width="1920" height="1356" alt="image" src="https://github.com/user-attachments/assets/e5145ef8-6ccb-4422-ad1a-138bea3b1422" />

Checklist:
* Self-reviewed code
* Tested form submission without selecting District — error message appears correctly
* Tested form with District selected — no extra space between District and City
* Verified spacing matches other form fields visually
* Verified no other validation rules affected