### PR TITLE
[TM-681] Feat: Blog role-based access — status badges, pending flow, admin approve/reject

### DIFF
--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   useFetchBlogByIdQuery,
   useFetchBlogsQuery,
   useDeleteBlogMutation,
+  useUpdateBlogStatusMutation,
 } from "@/store/api/splits/blogs";
 import { useAuthContext } from "@/contexts";
 import Link from "next/link";
@@ -53,6 +54,7 @@ export default function ViewBlogPage() {
   const { data: allBlogs } = useFetchBlogsQuery({});
   const { user } = useAuthContext();
   const [deleteBlog, { isLoading: isDeleting }] = useDeleteBlogMutation();
+  const [updateBlogStatus, { isLoading: isStatusUpdating }] = useUpdateBlogStatusMutation();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const handleDelete = async () => {
@@ -63,6 +65,16 @@ export default function ViewBlogPage() {
       router.push("/blogs");
     } catch {
       toast.error("Failed to delete blog");
+    }
+  };
+
+  const handleStatusChange = async (status: "approved" | "rejected") => {
+    if (!blog) return;
+    try {
+      await updateBlogStatus({ id: blog.id, status }).unwrap();
+      toast.success(status === "approved" ? "Blog approved successfully" : "Blog rejected");
+    } catch {
+      toast.error("Failed to update blog status");
     }
   };
 
@@ -105,7 +117,30 @@ export default function ViewBlogPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 lg:py-10">
       <div className="mb-2 lg:mb-4">
         {user && (blog.author?.id === user.id || user.role === "admin") && (
-          <div className="flex justify-end gap-2 mb-4 mt-6 lg:mt-0 lg:mb-6">
+          <div className="flex flex-wrap justify-end gap-2 mb-4 mt-6 lg:mt-0 lg:mb-6">
+            {/* Admin approve/reject — only shown when blog is pending or needs status change */}
+            {user.role === "admin" && (
+              <>
+                {(blog as any).status !== "approved" && (
+                  <button
+                    onClick={() => handleStatusChange("approved")}
+                    disabled={isStatusUpdating}
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-white px-5 py-2.5 rounded-lg bg-green-600 hover:bg-green-700 transition-colors duration-200 shadow-sm disabled:opacity-50"
+                  >
+                    ✓ Approve
+                  </button>
+                )}
+                {(blog as any).status !== "rejected" && (
+                  <button
+                    onClick={() => handleStatusChange("rejected")}
+                    disabled={isStatusUpdating}
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-white px-5 py-2.5 rounded-lg bg-orange-500 hover:bg-orange-600 transition-colors duration-200 shadow-sm disabled:opacity-50"
+                  >
+                    ✕ Reject
+                  </button>
+                )}
+              </>
+            )}
             <Link
               href={`/blogs/components/edit-blog/${blog.id}`}
               className="inline-flex items-center gap-2 text-sm font-semibold text-white px-5 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-700 transition-colors duration-200 shadow-sm"

--- a/src/app/blogs/components/ViewBlogs.tsx
+++ b/src/app/blogs/components/ViewBlogs.tsx
@@ -208,6 +208,22 @@ export default function BlogsDashboard() {
                           Tuition Lanka
                         </span>
                       </div>
+                      {(user?.role === "admin" || (blog as any).author?.id === user?.id) && (
+                          <span className={[
+                            "ml-auto px-2 py-0.5 rounded-full text-xs font-semibold",
+                            (blog as any).status === "approved"
+                              ? "bg-green-100 text-green-700"
+                              : (blog as any).status === "pending"
+                              ? "bg-yellow-100 text-yellow-700"
+                              : "bg-red-100 text-red-700",
+                          ].join(" ")}>
+                            {(blog as any).status === "approved"
+                              ? "Approved"
+                              : (blog as any).status === "pending"
+                              ? "Pending"
+                              : "Rejected"}
+                          </span>
+                        )}
                       {!imageSrc && (
                         <span className="ml-auto text-xs text-gray-400">
                           {blogDate.toLocaleDateString("en-US", {

--- a/src/app/blogs/components/create-blog/page.tsx
+++ b/src/app/blogs/components/create-blog/page.tsx
@@ -111,7 +111,7 @@ const AddBlog = () => {
         }
         return;
       }
-      toast.success("Blog created successfully!");
+      toast.success("Your blog has been submitted and is pending admin approval.");
       onRegisterSuccess();
     } catch (error) {
       console.error("Unexpected error during blog creation:", error);
@@ -747,7 +747,6 @@ const AddBlog = () => {
               ))}
             </div>
 
-            <input type="hidden" value="pending" {...register("status")} />
           </div>
         ) : (
           <>

--- a/src/app/blogs/components/create-blog/schema.ts
+++ b/src/app/blogs/components/create-blog/schema.ts
@@ -59,7 +59,6 @@ export const createArticleSchema = z.object({
   relatedArticles: z
     .array(z.string().min(1, "Related article ID is required"))
     .optional(),
-  status: z.enum(["pending", "published", "draft"]),
 });
 
 export type CreateArticleSchema = z.infer<typeof createArticleSchema>;
@@ -71,5 +70,4 @@ export const initialFormValues: CreateArticleSchema = {
   relatedArticles: [],
   tags: [],
   faqs: [],
-  status: "pending",
 };

--- a/src/app/blogs/components/edit-blog/[id]/page.tsx
+++ b/src/app/blogs/components/edit-blog/[id]/page.tsx
@@ -194,8 +194,10 @@ export default function EditBlogPage() {
   const onSubmit = async (data: UpdateArticleSchema) => {
     if (!user) return toast.error("Please authenticate");
 
+    const wasRejected = blog?.status === "rejected";
+
     try {
-      const payload = {
+      const payload: any = {
         id: blogId,
         blogId: blogId,
         title: data.title,
@@ -204,7 +206,6 @@ export default function EditBlogPage() {
         relatedArticles: data.relatedArticles ?? [],
         tags: data.tags ?? [],
         faqs: data.faqs ?? [],
-        status: (data.status || "pending") as "pending" | "published" | "draft",
       };
 
       const result = await updateBlog(payload);
@@ -223,7 +224,7 @@ export default function EditBlogPage() {
         }
         return;
       }
-      toast.success("Blog updated successfully!");
+      toast.success(wasRejected ? "Blog resubmitted for review." : "Blog updated successfully!");
       router.push(`/blogs/${blogId}`);
     } catch (err) {
       console.error(err);

--- a/src/app/blogs/components/edit-blog/schema.ts
+++ b/src/app/blogs/components/edit-blog/schema.ts
@@ -59,7 +59,7 @@ export const updateArticleSchema = z.object({
   relatedArticles: z
     .array(z.string().min(1, "Related article ID is required"))
     .optional(),
-  status: z.enum(["pending", "published", "draft"]),
+  status: z.enum(["pending", "approved", "rejected"]),
 });
 
 export type UpdateArticleSchema = z.infer<typeof updateArticleSchema>;

--- a/src/store/api/splits/blogs/index.ts
+++ b/src/store/api/splits/blogs/index.ts
@@ -61,6 +61,15 @@ export const BlogsApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: ["Blogs"],
     }),
+
+    updateBlogStatus: build.mutation<Blogs, { id: string; status: "approved" | "rejected" | "pending" }>({
+      query: ({ id, status }) => ({
+        url: `${Endpoints.Blogs}/${id}/status`,
+        method: "PATCH",
+        body: { status },
+      }),
+      invalidatesTags: (result, error, { id }) => [{ type: "Blogs", id }, "Blogs"],
+    }),
   }),
   overrideExisting: false,
 });
@@ -73,4 +82,5 @@ export const {
   useLazyFetchBlogByIdQuery,
   useCreateBlogMutation,
   useDeleteBlogMutation,
+  useUpdateBlogStatusMutation,
 } = BlogsApi;


### PR DESCRIPTION
Ticket: https://softvilmedia-team.atlassian.net/browse/TM-681

Summary: Implemented role-based blog access control including status
badges on blog cards, pending-only creation flow, rejected blog
resubmit flow for tutors, and admin approve/reject controls.

Changes:

Frontend:
* Added status badge (Approved/Pending/Rejected) on blog listing
  cards — visible only to blog author and admin (TM-734)
* Removed status from create blog payload — backend forces "pending"
  on every new blog (TM-735)
* Removed status from edit blog payload for all roles — admin status
  changes handled exclusively via PATCH /blogs/:id/status (TM-736)
* Tutor editing a rejected blog triggers backend auto-reset to pending
  with toast "Blog resubmitted for review."
* Added Approve and Reject buttons on blog detail page for admin only
* Approve button hidden when already approved
* Reject button hidden when already rejected

Files changed:
* src/app/blogs/components/ViewBlogs.tsx
* src/app/blogs/components/create-blog/schema.ts
* src/app/blogs/components/create-blog/page.tsx
* src/app/blogs/components/edit-blog/[id]/page.tsx
* src/store/api/splits/blogs/index.ts
* src/app/blogs/[slug]/page.tsx

Backend:
* No backend changes in this PR

Root Cause:
* Blog status flow was not aligned with backend API contract
* Status was being sent in create/edit payloads unnecessarily
* No status badges existed to reflect blog visibility state to
  authors and admins

Result:
* Blog cards show correct status badge per role
* New blogs always submitted as pending
* Rejected blogs can be edited and resubmitted by tutor
* Admin can approve or reject from blog detail page

Checklist:
* Self-reviewed code
* Tested create blog as tutor — verified Pending badge appears
* Tested admin approve — verified green Approved badge appears
* Tested admin reject — verified red Rejected badge appears
* Verified badge not visible to other tutors or students
* Tested tutor resubmit of rejected blog
* Tested admin approve/reject buttons on blog detail page
* Verified no other form fields or features affected

Jira Comment for TM-681:

Fixed in branch: feature/TM-681-blog-role-based-access

Files changed:
* src/app/blogs/components/ViewBlogs.tsx
* src/app/blogs/components/create-blog/schema.ts
* src/app/blogs/components/create-blog/page.tsx
* src/app/blogs/components/edit-blog/[id]/page.tsx
* src/store/api/splits/blogs/index.ts
* src/app/blogs/[slug]/page.tsx

Changes made:
* Status badge added to blog cards (author + admin visibility only)
* Status removed from create payload — backend controls it
* Status removed from edit payload — only PATCH /blogs/:id/status used
* Admin approve/reject buttons added on blog detail page

Result:
* Role-based blog access fully implemented on frontend ✅
* All 3 subtasks completed: TM-734, TM-735, TM-736 ✅