### PR TITLE
TM-567: Implement route scroll management and adjust navbar height

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,23 +10,23 @@
 @import "slick-carousel/slick/slick-theme.css";
 
 html {
-  --site-navbar-height: 72px;
+  --site-shell-offset: 72px;
   --scroll-behavior: smooth !important;
   scroll-behavior: smooth !important;
-  scroll-padding-top: var(--site-navbar-height);
+  scroll-padding-top: var(--site-shell-offset);
   max-width: 100%;
   overflow-x: clip;
 }
 
 @media (min-width: 640px) {
   html {
-    --site-navbar-height: 104px;
+    --site-shell-offset: 72px;
   }
 }
 
 @media (min-width: 768px) {
   html {
-    --site-navbar-height: 112px;
+    --site-shell-offset: 80px;
   }
 }
 
@@ -54,7 +54,7 @@ body {
 .site-shell {
   min-height: 100vh;
   min-height: 100dvh;
-  padding-top: var(--site-navbar-height);
+  padding-top: var(--site-shell-offset);
 }
 
 /* 
@@ -468,7 +468,7 @@ html:not([data-scroll="0"]) .border-right {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: calc(var(--site-navbar-height) * -1);
+  margin-top: calc(var(--site-shell-offset) * -1);
 }
 
 .hero-video {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,10 +10,24 @@
 @import "slick-carousel/slick/slick-theme.css";
 
 html {
+  --site-navbar-height: 72px;
   --scroll-behavior: smooth !important;
   scroll-behavior: smooth !important;
+  scroll-padding-top: var(--site-navbar-height);
   max-width: 100%;
   overflow-x: clip;
+}
+
+@media (min-width: 640px) {
+  html {
+    --site-navbar-height: 104px;
+  }
+}
+
+@media (min-width: 768px) {
+  html {
+    --site-navbar-height: 112px;
+  }
 }
 
 /* 
@@ -35,6 +49,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
   max-width: 100%;
   overflow-x: clip;
+}
+
+.site-shell {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding-top: var(--site-navbar-height);
 }
 
 /* 
@@ -441,22 +461,14 @@ html:not([data-scroll="0"]) .border-right {
 .hero-section {
   position: relative;
   width: 100%;
-  height: 100vh;
-  min-height: 100svh;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: -3rem;
-  /* counteract pt-12 on <main> (mobile) */
-}
-
-@media (min-width: 640px) {
-  .hero-section {
-    margin-top: -5rem;
-    /* counteract sm:pt-20 on <main> */
-  }
+  margin-top: calc(var(--site-navbar-height) * -1);
 }
 
 .hero-video {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import NavBar from "@/components/shared/navbar";
 import Script from "next/script";
 import Footer from "@/components/shared/footer";
 import BackToTop from "@/components/shared/back-to-top";
+import RouteScrollManager from "@/components/shared/route-scroll-manager";
 import "./globals.css";
 import { WithProviders } from "@/hocs/with-providers";
 
@@ -23,7 +24,8 @@ export default function RootLayout({
       <body>
         <Script src="/env-config.js" strategy="afterInteractive" />
         <WithProviders>
-          <main className="bg-lightwhite pt-12 sm:pt-20 flex flex-col min-h-screen">
+          <RouteScrollManager />
+          <main className="site-shell bg-lightwhite flex flex-col">
             <NavBar />
             <div className="flex-1">{children}</div>
             <Footer />

--- a/src/components/shared/route-scroll-manager/index.tsx
+++ b/src/components/shared/route-scroll-manager/index.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+const RouteScrollManager = () => {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const previousRestoration = window.history.scrollRestoration;
+    window.history.scrollRestoration = "manual";
+
+    return () => {
+      window.history.scrollRestoration = previousRestoration;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hash) return;
+
+    const scrollToPageTop = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+      document.documentElement.scrollTop = 0;
+      document.body.scrollTop = 0;
+    };
+
+    const frame = requestAnimationFrame(() => {
+      scrollToPageTop();
+      setTimeout(scrollToPageTop, 0);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [pathname]);
+
+  return null;
+};
+
+export default RouteScrollManager;


### PR DESCRIPTION
Ticket: [TM-567](https://softvilmedia-team.atlassian.net/browse/TM-567?atlOrigin=eyJpIjoiYWEyMGY0M2Q5ZTE2NGIyYThiNjVlZGY0OGFlZDZiZDAiLCJwIjoiaiJ9)

Summary: Fixed the mobile UI on initial page load where top content could appear cut off or misaligned under the fixed navbar, and fixed route navigation so new pages scroll fully to the top.

Changes:

Frontend:
* introduced a shared `--site-navbar-height` CSS variable for consistent fixed-header spacing across breakpoints
* added `scroll-padding-top` using the shared navbar height
* replaced hard-coded top padding on the app shell with a shared `.site-shell` layout class
* updated the home hero section to use the same navbar offset instead of hard-coded negative margins
* switched hero sizing to `100dvh`-based min-height for more stable mobile viewport rendering
* added a route-level scroll manager component
* disabled browser auto scroll restoration in-app and reset scroll to `(0, 0)` on pathname changes
* preserved hash-based navigation behaviour so section links still work correctly

Files changed:
* `src/app/globals.css`
* `src/app/layout.tsx`
* `src/components/shared/route-scroll-manager/index.tsx`

Backend:
* no backend changes in this PR

Root Cause:
* the navbar is fixed-position, but the page shell used smaller hard-coded top padding than the navbar’s actual rendered height on mobile
* the hero section used separate hard-coded offsets, which caused first-paint alignment issues
* route changes were not consistently resetting scroll position to the real top of the page

Result:
* first visible content no longer renders underneath the fixed navbar on mobile
* initial page load is aligned correctly without requiring scroll or refresh
* hero spacing stays consistent with the shared navbar height
* navigating to a new page now scrolls fully to the top
* anchor/hash navigation still works as expected