### PR TITLE
Fix tutor profile personal info form behavior and read-only field messaging

### DIFF
--- a/src/app/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/profile/[id]/components/form-general-information/index.tsx
@@ -128,11 +128,12 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
               />
 
               <InputText
-                label="Email *"
+                label="Email"
                 placeholder="Email address"
                 name="email"
                 type="text"
                 disabled
+                helperText="Email is read-only here. Contact support if you need to change it."
               />
               <InputText
                 label="Contact Number *"
@@ -155,6 +156,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 type="number"
                 disabled
                 placeholder="Auto-calculated"
+                helperText="Age is read-only and updates automatically from your date of birth."
               />
               <InputSelect
                 label="Gender *"

--- a/src/app/profile/[id]/components/form-general-information/schema.ts
+++ b/src/app/profile/[id]/components/form-general-information/schema.ts
@@ -45,7 +45,10 @@ export const generalInfoSchema = z.object({
     z
       .string()
       .min(1, "Full Name is required")
-      .regex(/^[A-Za-z\s]+$/, "Full Name can contain letters and spaces only"),
+      .regex(
+        /^[A-Za-z][A-Za-z\s'.-]*$/,
+        "Full Name can contain letters, spaces, apostrophes, periods, and hyphens only",
+      ),
   ),
   email: z.preprocess(trimOnly, z.string().email("Invalid email address")),
   phoneNumber: z.preprocess(

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -110,6 +110,9 @@ const formatBirthdayForInput = (birthday?: string | Date) => {
 const getProfileBirthday = (profile: ProfileResponse) =>
   profile.birthday || profile.dateOfBirth || "";
 
+const getProfileDisplayName = (profile: ProfileResponse) =>
+  profile.fullName || profile.name || "";
+
 const serializeBirthdayForPayload = (birthday: GeneralInfoSchema["birthday"]) =>
   birthday instanceof Date ? birthday.toISOString().slice(0, 10) : birthday;
 
@@ -147,7 +150,7 @@ const useLogic = (): LogicReturnType => {
   const params = useParams();
   const router = useRouter();
   const userId = params?.id as string;
-  const { user, isUserLoaded } = useAuthContext();
+  const { user, isUserLoaded, updateUser } = useAuthContext();
 
   const [userRawData, setUserRawData] = useState<ProfileResponse | null>(null);
   const [educationSubjectsOptions, setEducationSubjectsOptions] = useState<
@@ -217,7 +220,7 @@ const useLogic = (): LogicReturnType => {
       const birthday = getProfileBirthday(profile);
 
       generalInfoForm.reset({
-        name: profile.name || profile.fullName || "",
+        name: getProfileDisplayName(profile),
         email: profile.email ?? "",
         phoneNumber: profile.phoneNumber || profile.contactNumber || "",
         birthday: formatBirthdayForInput(birthday) as any,
@@ -423,10 +426,21 @@ const useLogic = (): LogicReturnType => {
       return;
     }
 
-    generalInfoForm.reset({
-      ...data,
-      birthday: formatBirthdayForInput(birthday as string) as any,
-    });
+    const updatedProfile = result.data;
+    const resolvedName = updatedProfile
+      ? getProfileDisplayName(updatedProfile)
+      : data.name;
+
+    if (updatedProfile) {
+      hydrateProfileForms(updatedProfile);
+    } else {
+      generalInfoForm.reset({
+        ...data,
+        birthday: formatBirthdayForInput(birthday as string) as any,
+      });
+    }
+
+    updateUser({ name: resolvedName });
     toast.success("Personal information updated successfully");
   };
 

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -432,7 +432,8 @@ const useLogic = (): LogicReturnType => {
       : data.name;
 
     if (updatedProfile) {
-      hydrateProfileForms(updatedProfile);
+      setUserRawData(updatedProfile);
+      prePopulateGeneralForm(updatedProfile);
     } else {
       generalInfoForm.reset({
         ...data,

--- a/src/components/shared/input-text/index.tsx
+++ b/src/components/shared/input-text/index.tsx
@@ -13,6 +13,8 @@ const InputText: React.FC<InputTextProps> = ({
   helperText,
   className = "",
   name,
+  onBlur,
+  onChange,
   ...props
 }) => {
   const { control, formState } = useFormContext();
@@ -39,15 +41,29 @@ const InputText: React.FC<InputTextProps> = ({
         render={({ field }) => (
           <>
             <input
-              {...field}
               {...props}
-              className={`h-11 w-full rounded-md border px-3 text-darkpurple placeholder:text-darkgrey focus:outline-none focus:ring-2 focus:ring-primary-500 ${
+              name={field.name}
+              ref={field.ref}
+              value={field.value ?? ""}
+              onChange={(event) => {
+                field.onChange(event);
+                onChange?.(event);
+              }}
+              onBlur={(event) => {
+                onBlur?.(event);
+                field.onBlur();
+              }}
+              className={`h-11 w-full rounded-md border px-3 text-darkpurple placeholder:text-darkgrey focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 disabled:opacity-100 ${
                 error ? "border-red-500" : "border-linegrey"
               } ${className}`}
             />
 
             {(error || helperText) && (
-              <span className="text-xs text-red-500 mt-1">
+              <span
+                className={`mt-1 text-xs ${
+                  error ? "text-red-500" : "text-gray-500"
+                }`}
+              >
                 {error || helperText}
               </span>
             )}


### PR DESCRIPTION
This PR fixes several issues in the tutor profile personal information section.

Changes:

- Fixed the full name field so form changes are correctly tracked by React Hook Form.
- Fixed profile name hydration/update flow to prefer fullName when available.
- Synced the updated name back into auth state so the UI reflects the latest profile name after save.
- Relaxed full name validation to allow spaces, apostrophes, periods, and hyphens.
- Replaced the ES6-only regex with an ES5-safe version to match the current TypeScript target.
- Improved disabled input styling so read-only fields look intentional in the UI.
- Added helper text for read-only email and auto-calculated age fields.

Files touched:

- src/app/profile/[id]/hooks/useLogic.tsx
- src/app/profile/[id]/components/form-general-information/index.tsx
- src/app/profile/[id]/components/form-general-information/schema.ts
- src/components/shared/input-text/index.tsx