### PR TITLE
TM-758 Fix testimonial heading responsiveness on tablet and laptop screens

### DIFF
--- a/src/components/home-page/testimonials/index.tsx
+++ b/src/components/home-page/testimonials/index.tsx
@@ -255,13 +255,13 @@ const Testimonials: FC = () => {
       <div className="mx-auto max-w-7xl px-4 lg:px-8">
         {/* ── Stacked heading ── */}
         <div className="text-center overflow-hidden animate-fade-in mb-10">
-          <h2 className="text-4xl font-bold text-black leading-[1.2] my-1">
+          <h2 className="text-[clamp(1.5rem,6vw,2.25rem)] font-bold text-black leading-[1.2] my-1 whitespace-nowrap">
             See what others are saying.
           </h2>
-          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-40 lg:mr-48 my-1 hidden md:block">
+          <h2 className="text-[clamp(1.5rem,6vw,2.25rem)] font-bold text-black leading-[1.2] opacity-40 lg:mr-48 my-1 whitespace-nowrap hidden min-[900px]:block">
             See what others are saying.
           </h2>
-          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-20 lg:-mr-32 my-1 hidden md:block">
+          <h2 className="text-[clamp(1.5rem,6vw,2.25rem)] font-bold text-black leading-[1.2] opacity-20 lg:-mr-32 my-1 whitespace-nowrap hidden min-[900px]:block">
             See what others are saying.
           </h2>
         </div>

--- a/src/components/home-page/testimonials/index.tsx
+++ b/src/components/home-page/testimonials/index.tsx
@@ -258,10 +258,10 @@ const Testimonials: FC = () => {
           <h2 className="text-4xl font-bold text-black leading-[1.2] my-1">
             See what others are saying.
           </h2>
-          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-40 lg:mr-48 my-1 hidden sm:block">
+          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-40 lg:mr-48 my-1 hidden md:block">
             See what others are saying.
           </h2>
-          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-20 lg:-mr-32 my-1 hidden sm:block">
+          <h2 className="text-4xl font-bold text-black leading-[1.2] opacity-20 lg:-mr-32 my-1 hidden md:block">
             See what others are saying.
           </h2>
         </div>


### PR DESCRIPTION
Ticket - [TM-758](https://softvilmedia-team.atlassian.net/browse/TM-758?atlOrigin=eyJpIjoiZmMwNjUwZjZmYTExNDQxODkzNzFlYjU3OTkwNjVjY2IiLCJwIjoiaiJ9)

This PR fixes the testimonials heading in the homepage section for responsive breakpoints.

The “See what others are saying” heading was showing the layered desktop treatment on tablet-sized screens, which made the title appear duplicated. This update keeps the heading as a single clean line on smaller widths while preserving the layered effect for laptop and desktop layouts.

**Changes**
- Kept the testimonial heading on a single line
- Preserved the layered/faded heading effect for larger screens
- Updated the visibility breakpoint so the layered version appears only from `900px` and above
- Ensured tablet-sized screens show only one heading line

**Testing**
- Checked `768px` view: only one heading is shown
- Checked `900px+` view: layered heading effect is shown
- Confirmed the heading remains on one line across the affected breakpoints