### PR TITLE
Fix Blog related articles editing and clear form reset behaviour

### DIFF
--- a/src/app/blogs/components/create-blog/page.tsx
+++ b/src/app/blogs/components/create-blog/page.tsx
@@ -37,6 +37,7 @@ const AddBlog = () => {
   const { user } = useAuthContext();
 
   const [isPreview, setIsPreview] = useState(false);
+  const [clearVersion, setClearVersion] = useState(0);
 
   const createBlogForm = useForm<CreateArticleSchema>({
     resolver: zodResolver(createArticleSchema),
@@ -128,6 +129,7 @@ const AddBlog = () => {
 
   const onClear = () => {
     reset(initialFormValues);
+    setClearVersion((version) => version + 1);
   };
 
   return (
@@ -651,6 +653,7 @@ const AddBlog = () => {
               <Label htmlFor="coverImage">Cover Image</Label>
 
               <FileUploadDropzone
+                key={`cover-image-${clearVersion}`}
                 onUploaded={(url) =>
                   createBlogForm.setValue("image", encodeImageUrl(url))
                 }
@@ -677,6 +680,7 @@ const AddBlog = () => {
                 control={control}
                 render={({ field }) => (
                   <MultiSelect
+                    key={`related-articles-${clearVersion}`}
                     label=""
                     options={blogOptions}
                     defaultSelected={field.value || []}
@@ -693,6 +697,7 @@ const AddBlog = () => {
                 control={control}
                 render={({ field }) => (
                   <MultiSelect
+                    key={`tags-${clearVersion}`}
                     label=""
                     options={tagOptions}
                     defaultSelected={field.value || []}

--- a/src/app/blogs/components/edit-blog/[id]/page.tsx
+++ b/src/app/blogs/components/edit-blog/[id]/page.tsx
@@ -114,6 +114,12 @@ export default function EditBlogPage() {
   const tagsOptions: Option[] =
     tagsData?.results?.map((t) => ({ value: t.id, text: t.name })) || [];
 
+  const blogOptions: Option[] =
+    blogsData?.results?.map((blog) => ({
+      value: blog.id,
+      text: blog.title,
+    })) || [];
+
   const [showAuthDialog, setShowAuthDialog] = useState(false);
 
   // Guard 1: unauthenticated users → show a login prompt dialog
@@ -811,6 +817,23 @@ export default function EditBlogPage() {
                   className="mt-2 max-h-48 w-full rounded-lg object-cover"
                 />
               )}
+            </div>
+
+            <div>
+              <Label>Related Articles</Label>
+              <Controller
+                control={control}
+                name="relatedArticles"
+                render={({ field }) => (
+                  <MultiSelect
+                    key={JSON.stringify(field.value)}
+                    options={blogOptions}
+                    defaultSelected={field.value}
+                    onChange={field.onChange}
+                    label={""}
+                  />
+                )}
+              />
             </div>
 
             <div>

--- a/src/components/form-controls/multi-select/index.tsx
+++ b/src/components/form-controls/multi-select/index.tsx
@@ -55,6 +55,22 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
     (value) => options.find((o) => o.value === value)?.text || "",
   );
 
+  const defaultSelectedKey = defaultSelected.join("|");
+  const optionSelectedKey = options
+    .filter((o) => o.selected)
+    .map((o) => o.value)
+    .join("|");
+
+  useEffect(() => {
+    setSelectedOptions(
+      defaultSelected.length > 0
+        ? defaultSelected
+        : options.filter((o) => o.selected).map((o) => o.value),
+    );
+    // Sync with form resets without reacting to every options array recreation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSelectedKey, optionSelectedKey]);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (


### PR DESCRIPTION

This PR fixes two Blog module issues:

- Adds the missing **Related Articles** selector to the Edit Blog page.
- Fixes the Blog Creation form **Clear** button so Cover Image, Related Articles, and Tags are fully reset.

## Changes

- Added `blogOptions` and a `relatedArticles` `MultiSelect` controller to the Edit Blog form.
- Added a `clearVersion` key in the Blog Creation form to remount reset-sensitive fields after Clear.
- Updated the shared `MultiSelect` component to sync its selected state when form reset/default values change.
