### PR TITLE
fix: improve class type selection logic in education form prepopulation

### DIFF
--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -593,9 +593,10 @@ const useLogic = (): LogicReturnType => {
 
   const prePopulateEducationForm = useCallback(
     (profile: ProfileResponse) => {
-      const classType = normalizeArrayValue(
-        profile.classType ?? profile.tutoringLevels,
-      );
+      const profileClassType = normalizeArrayValue(profile.classType);
+      const classType = profileClassType.length
+        ? profileClassType
+        : normalizeArrayValue(profile.tutoringLevels);
 
       educationInfoForm.reset({
         classType,


### PR DESCRIPTION

## Summary
Fixed the User Profile Qualifications section so Class Type values are correctly prepopulated when tutor profile data is loaded.

## Changes

### Frontend
* Updated profile education form prepopulation logic to fall back to `tutoringLevels` when `classType` is empty.

### Backend
* No backend changes in this PR

## Files Changed
* `src/app/profile/[id]/hooks/useLogic.tsx`

## Root Cause
* The profile prepopulation logic used `profile.classType ?? profile.tutoringLevels`. When `classType` existed as an empty array, the fallback to `tutoringLevels` did not run, so the form could show Class Type as missing.

## Result
* User Profile → Qualifications now displays Class Type values correctly when available through `tutoringLevels`.