### PR TITLE
Fix/tm 844 939 942 943 948 949 950 client portal bugs

### DIFF
--- a/src/app/grades-and-subjects/page.tsx
+++ b/src/app/grades-and-subjects/page.tsx
@@ -24,6 +24,48 @@ import { AL_STREAM_ORDER } from "@/configs/options";
 const GRADE_LIMIT = 1000;
 const UNKNOWN_AL_STREAM_ORDER = AL_STREAM_ORDER.length;
 
+const STREAM_SUBJECT_ORDER: { pattern: RegExp; order: string[] }[] = [
+  {
+    pattern: /biological\s+science/i,
+    order: [
+      "biology",
+      "physics",
+      "chemistry",
+      "agriculture",
+      "general information technology",
+      "general english",
+      "common general test",
+    ],
+  },
+  {
+    pattern: /commerce/i,
+    order: [
+      "accounting",
+      "economics",
+      "business studies",
+      "ict (advanced level)",
+      "general information technology",
+      "general english",
+      "common general test",
+    ],
+  },
+];
+
+const sortSubjects = (
+  gradeTitle: string,
+  subjects: { id: string; title: string; description: string }[],
+) => {
+  const stream = STREAM_SUBJECT_ORDER.find(({ pattern }) =>
+    pattern.test(gradeTitle),
+  );
+  if (!stream) return subjects;
+  return [...subjects].sort((a, b) => {
+    const ai = stream.order.indexOf(a.title.toLowerCase());
+    const bi = stream.order.indexOf(b.title.toLowerCase());
+    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+  });
+};
+
 const normalizeTitle = (title: string) => title.toLowerCase();
 
 const getAlStreamOrder = (title: string) => {
@@ -61,8 +103,7 @@ const GradeDetailDialog: FC<GradeDetailDialogProps> = ({
     skip: !gradeId,
   });
 
-  const subjects: { id: string; title: string; description: string }[] =
-    data?.subjects ?? [];
+  const subjects = sortSubjects(data?.title ?? "", data?.subjects ?? []);
 
   return (
     <Dialog.Root open={!!gradeId} onOpenChange={(open) => !open && onClose()}>

--- a/src/app/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/profile/[id]/components/form-education-information/index.tsx
@@ -1,5 +1,5 @@
 import InputText from "@/components/shared/input-text";
-import { Controller, FormProvider, SubmitHandler } from "react-hook-form";
+import { Controller, FormProvider, SubmitHandler, useFieldArray } from "react-hook-form";
 import InputMultiSelect from "@/components/shared/input-multi-select";
 import InputSelect from "@/components/shared/input-select";
 import MultiFileUploadDropzone from "@/components/upload/multi-file-upload-dropzone";
@@ -11,11 +11,14 @@ import {
   TUTOR_TYPE_OPTIONS,
   isPhysicalClassType,
 } from "@/configs/register-tutor";
+import { DOCUMENT_TYPE_OPTIONS } from "@/configs/options";
 import { Option } from "@/types/shared-types";
 import { FC, useEffect } from "react";
 import { EducationInfoSchema } from "./schema";
 import SubmitButton from "@/components/shared/submit-button";
 import { isEmpty } from "lodash-es";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   dropdownOptionData: {
@@ -36,6 +39,11 @@ const tutorTypeOptions = toOptions(TUTOR_TYPE_OPTIONS);
 const tutorMediumOptions = toOptions(MEDIUM_OPTIONS);
 const highestEducationOptions = toOptions(REGISTER_HIGHEST_EDUCATION_OPTIONS);
 
+const selectClass =
+  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
+const selectBorder = (hasError: boolean) =>
+  hasError ? "border-red-500" : "border-gray-300";
+
 const FormEducationInfo: FC<Props> = ({
   dropdownOptionData: { gradesOptions, subjectsOptions },
   form,
@@ -43,6 +51,14 @@ const FormEducationInfo: FC<Props> = ({
   isSubmitting,
 }) => {
   const { isDirty, isValid } = form.formState;
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "certificatesAndQualifications",
+  });
+
+  const certErrors =
+    (form.formState.errors.certificatesAndQualifications as any) ?? [];
   const [
     classType,
     preferredLocations,
@@ -172,27 +188,107 @@ const FormEducationInfo: FC<Props> = ({
               />
             </div>
 
-            <div className="mt-5 grid grid-cols-1 gap-4 sm:gap-5 lg:gap-6">
-              <Controller
-                name="certificatesAndQualifications"
-                control={form.control}
-                render={({ field, fieldState }) => (
-                  <div className="flex flex-col gap-1">
-                    <label className="block text-sm font-medium leading-6 text-gray-900">
-                      Certificates <span className="text-red-500">*</span>
-                    </label>
-                    <MultiFileUploadDropzone
-                      initialUrls={field.value}
-                      onUploaded={(urls) => field.onChange(urls ?? [])}
-                    />
-                    {fieldState.error?.message && (
-                      <span className="text-xs text-red-500">
-                        {fieldState.error.message}
-                      </span>
-                    )}
-                  </div>
-                )}
-              />
+            <div className="mt-5">
+              <label className="block text-sm font-medium leading-6 text-gray-900 mb-3">
+                Certificates <span className="text-red-500">*</span>
+              </label>
+
+              <div className="space-y-3">
+                {fields.map((field, index) => {
+                  const rowErrors = certErrors[index] ?? {};
+                  return (
+                    <div
+                      key={field.id}
+                      className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50"
+                    >
+                      {/* Document Type */}
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs text-gray-500 font-medium mb-1">
+                          Document Type
+                        </span>
+                        <Controller
+                          name={`certificatesAndQualifications.${index}.type`}
+                          control={form.control}
+                          render={({ field: f }) => (
+                            <select
+                              {...f}
+                              className={`${selectClass} ${selectBorder(!!rowErrors.type)}`}
+                            >
+                              <option value="" disabled hidden>
+                                Select type…
+                              </option>
+                              {DOCUMENT_TYPE_OPTIONS.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                  {opt.text}
+                                </option>
+                              ))}
+                            </select>
+                          )}
+                        />
+                        {rowErrors.type && (
+                          <p className="text-xs text-red-500">
+                            {rowErrors.type.message}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Upload Dropzone */}
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs text-gray-500 font-medium mb-1">
+                          Upload File
+                        </span>
+                        <Controller
+                          name={`certificatesAndQualifications.${index}.url`}
+                          control={form.control}
+                          render={({ field: f }) => (
+                            <MultiFileUploadDropzone
+                              initialUrls={f.value ? [f.value] : []}
+                              onUploaded={(urls) =>
+                                f.onChange(urls[urls.length - 1] ?? "")
+                              }
+                            />
+                          )}
+                        />
+                        {rowErrors.url && (
+                          <p className="text-xs text-red-500">
+                            {rowErrors.url.message}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Remove Button */}
+                      <div className="flex items-start pt-7">
+                        <button
+                          type="button"
+                          onClick={() => remove(index)}
+                          disabled={fields.length === 1}
+                          className="p-2 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                          title="Remove this document"
+                        >
+                          <Trash2 size={18} />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {typeof form.formState.errors.certificatesAndQualifications?.message === "string" && (
+                <p className="text-xs text-red-500 mt-1">
+                  {form.formState.errors.certificatesAndQualifications.message}
+                </p>
+              )}
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3 flex items-center gap-1.5"
+                onClick={() => append({ type: "", url: "" })}
+              >
+                <Plus size={15} />
+                Add Document
+              </Button>
             </div>
             <div className="col-span-6 sm:col-full">
               <SubmitButton

--- a/src/app/profile/[id]/components/form-education-information/schema.ts
+++ b/src/app/profile/[id]/components/form-education-information/schema.ts
@@ -23,14 +23,19 @@ export const educationInfoSchema = z
           invalid_type_error: "Years of Experience is required",
           required_error: "Years of Experience is required",
         })
-        .min(0, "Years of Experience cannot be negative")
+        .min(1, "Years of Experience must be greater than 0")
         .max(50, "Experience cannot exceed 50 years"),
     ),
     tutorMediums: requiredMultiSelect("Tutor Mediums are required"),
     grades: requiredMultiSelect("Grades are required"),
     subjects: requiredMultiSelect("Subjects are required"),
     certificatesAndQualifications: z
-      .array(z.string())
+      .array(
+        z.object({
+          type: z.string().optional().default(""),
+          url: z.string().min(1, "Please upload a file"),
+        }),
+      )
       .min(1, "Certificates are required"),
   })
   .superRefine(({ classType, preferredLocations }, ctx) => {
@@ -55,7 +60,7 @@ export const initialEducationInfoFormValues = {
   tutorMediums: [] as string[],
   grades: [] as string[],
   subjects: [] as string[],
-  certificatesAndQualifications: [] as string[],
+  certificatesAndQualifications: [] as { type: string; url: string }[],
 };
 
 export type EducationInfoSchema = z.infer<typeof educationInfoSchema>;

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -611,7 +611,7 @@ const useLogic = (): LogicReturnType => {
         subjects: getProfileSubjectIds(profile),
         certificatesAndQualifications: normalizeCertificateUrls(
           profile.certificatesAndQualifications,
-        ),
+        ).map((url) => ({ type: "", url })),
       });
     },
     [educationInfoForm],
@@ -868,7 +868,9 @@ const useLogic = (): LogicReturnType => {
       tutorMediums: data.tutorMediums,
       grades: data.grades,
       subjects: data.subjects,
-      certificatesAndQualifications: data.certificatesAndQualifications,
+      certificatesAndQualifications: data.certificatesAndQualifications
+        .map((c) => c.url)
+        .filter(Boolean),
     };
 
     const result = await handleProfileSubmit({

--- a/src/app/register-tutor/schema.ts
+++ b/src/app/register-tutor/schema.ts
@@ -195,10 +195,21 @@ export const step2Schema = z.object({
 
   subjects: z.array(z.string()).min(1, "Subjects are required"),
 
-  yearsExperience: z
-    .number()
-    .min(1, "Years of Experience is required")
-    .max(50, "Experience cannot exceed 50 years"),
+  yearsExperience: z.preprocess(
+    (value) => {
+      if (value === "" || value === null || value === undefined) {
+        return undefined;
+      }
+      return Number(value);
+    },
+    z
+      .number({
+        invalid_type_error: "Years of Experience is required",
+        required_error: "Years of Experience is required",
+      })
+      .min(1, "Years of Experience must be greater than 0")
+      .max(50, "Experience cannot exceed 50 years"),
+  ),
 });
 
 export const step3Schema = z.object({

--- a/src/components/auth/form-login/index.tsx
+++ b/src/components/auth/form-login/index.tsx
@@ -22,31 +22,29 @@ const FormLogin = ({ onRegisterClick, onForgotPasswordClick }: Props) => {
     mode: "onChange",
   });
 
-  useEffect(() => {
-    const subscription = loginForm.watch((values, { name }) => {
-      if (isAuthError) setIsAuthError(null);
+  const emailValue = loginForm.watch("email");
+  const passwordValue = loginForm.watch("password");
 
-      if (
-        name === "email" &&
-        typeof values.email === "string" &&
-        /\s/.test(values.email)
-      ) {
-        loginForm.setValue("email", values.email.replace(/\s/g, ""), {
-          shouldValidate: true,
-        });
-      }
-      if (
-        name === "password" &&
-        typeof values.password === "string" &&
-        /\s/.test(values.password)
-      ) {
-        loginForm.setValue("password", values.password.replace(/\s/g, ""), {
-          shouldValidate: true,
-        });
-      }
-    });
-    return () => subscription.unsubscribe();
-  }, [isAuthError, loginForm, setIsAuthError]);
+  useEffect(() => {
+    if (isAuthError) setIsAuthError(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [emailValue, passwordValue]);
+
+  useEffect(() => {
+    if (emailValue && /\s/.test(emailValue)) {
+      loginForm.setValue("email", emailValue.replace(/\s/g, ""), {
+        shouldValidate: true,
+      });
+    }
+  }, [emailValue, loginForm]);
+
+  useEffect(() => {
+    if (passwordValue && /\s/.test(passwordValue)) {
+      loginForm.setValue("password", passwordValue.replace(/\s/g, ""), {
+        shouldValidate: true,
+      });
+    }
+  }, [passwordValue, loginForm]);
 
   useEffect(() => {
     if (isAuthError) {
@@ -71,7 +69,7 @@ const FormLogin = ({ onRegisterClick, onForgotPasswordClick }: Props) => {
             label="Email"
             name="email"
             placeholder="jhon@xyz.com"
-            type="email"
+            type="text"
           />
           <InputPassword
             label="Password"

--- a/src/components/shared/MultiSelect/index.tsx
+++ b/src/components/shared/MultiSelect/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable unused-imports/no-unused-vars */
 
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, X } from "lucide-react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 interface Option {
@@ -137,15 +137,31 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
         <div className="absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white shadow">
           {searchable && (
             <div className="p-2 border-b border-gray-100">
-              <input
-                ref={searchInputRef}
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onClick={(e) => e.stopPropagation()}
-                placeholder="Search..."
-                className="w-full rounded-md border border-gray-200 px-3 py-1.5 text-sm outline-none focus:border-blue-400"
-              />
+              <div className="relative">
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  placeholder="Search..."
+                  className="w-full rounded-md border border-gray-200 px-3 py-1.5 pr-8 text-sm outline-none focus:border-blue-400"
+                />
+                {searchQuery && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSearchQuery("");
+                      searchInputRef.current?.focus();
+                    }}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                    aria-label="Clear search"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </div>
             </div>
           )}
           <div className="max-h-52 overflow-y-auto">


### PR DESCRIPTION
## Tickets
TM-844 | TM-939 | TM-942 | TM-943 | TM-948 | TM-949

## Summary
Fixes multiple client portal bugs across login validation, tutor registration,
user profile qualifications, and the Grades & Subjects academics page.

## Changes

**TM-844 — Login form accepts spaces in email and password**
- Switched from subscription callback to direct `watch` + `useEffect` per field
  for reliable real-time space stripping in both InputText and InputPassword
- Changed email input `type="email"` → `type="text"` to prevent browsers
  silently discarding leading spaces before reporting to react-hook-form

**TM-939 — No clear button on Preferred Locations search field**
- Added X clear button inside MultiSelect searchable input
- Button appears when search query is non-empty; clicking it clears the query
  and keeps focus on the input
- Applies to all searchable MultiSelect fields across the app

**TM-942 — Years of Experience accepts 0 as valid value**
- Added `z.preprocess` to register tutor schema to handle empty string input
  and prevent "Expected number, received nan" error message
- Updated `.min(1)` message to "Years of Experience must be greater than 0"
  to correctly distinguish empty vs zero input

**TM-943 — Profile qualification section missing document type upload structure**
- Replaced single file dropzone with dynamic document rows matching the
  Register as a Tutor form: Document Type dropdown + file upload + remove button
  per row, with "+ Add Document" button
- Schema updated: `certificatesAndQualifications` from `string[]`
  to `{ type?: string, url: string }[]`
- useLogic updated to convert API `string[]` → `{ type, url }[]` on load
  and extract URLs back to `string[]` on submit — no backend change required

**TM-948 — Incorrect subject order for Biological Science Stream**
**TM-949 — Incorrect subject order for Commerce Stream**
- Added `STREAM_SUBJECT_ORDER` config with regex pattern + expected subject
  order per A/L stream
- Biological Science: Biology → Physics → Chemistry → Agriculture →
  General Information Technology → General English → Common General Test
- Commerce: Accounting → Economics → Business Studies → ICT (Advanced Level) →
  General Information Technology → General English → Common General Test
- Sort only applies when grade title matches a known stream pattern;
  all other grades are unaffected

## Files Changed
- `src/components/auth/form-login/index.tsx`
- `src/components/shared/MultiSelect/index.tsx`
- `src/app/register-tutor/schema.ts`
- `src/app/profile/[id]/components/form-education-information/schema.ts`
- `src/app/profile/[id]/components/form-education-information/index.tsx`
- `src/app/profile/[id]/hooks/useLogic.tsx`
- `src/app/grades-and-subjects/page.tsx`

## Root Cause
- TM-844: `type="email"` causes browsers to silently drop leading spaces;
  subscription callback unreliable for InputPassword component
- TM-939: No clear affordance existed on the search input in MultiSelect
- TM-942: Missing `z.preprocess` caused NaN error; wrong min message used for 0
- TM-943: Profile page used a simpler upload-only implementation that was never
  updated to match the structured document upload added to the registration form
- TM-948/949: Subjects returned from the API in unstructured order with no
  frontend sorting applied for specific A/L streams

## Result
- Login form rejects spaces in email (including leading) and password in real time
- Preferred Locations search field has a one-click clear button
- Years of Experience shows correct error messages for empty and zero values
- User Profile qualification section matches Register as a Tutor document upload UI
- Biological Science and Commerce stream subjects display in correct academic order

## Checklist
- [ ] TM-844: Test login with leading/middle/trailing spaces in email and password
- [ ] TM-939: Test search clear button in Preferred Locations on register tutor form
- [ ] TM-942: Enter 0 and empty in Years of Experience on both forms
- [ ] TM-943: Test adding, removing, and uploading documents in profile qualifications
- [ ] TM-948: Open Biological Science Stream modal and verify subject order
- [ ] TM-949: Open Commerce Stream modal and verify subject order
- [ ] Verify no regression on other forms using MultiSelect or InputSelect