### PR TITLE
feat: adding back to top button for the mobile and desktop view 

### DIFF
--- a/src/components/shared/back-to-top/index.tsx
+++ b/src/components/shared/back-to-top/index.tsx
@@ -29,10 +29,11 @@ const BackToTop: FC = () => {
   }, []);
 
   return (
-    <div className="hidden lg:block fixed bottom-4 right-4">
+    <div className="fixed bottom-4 right-4 z-50">
       {isVisible && (
         <button
           onClick={scrollToTop}
+          aria-label="Back to top"
           className="p-3 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
         >
           <Icon name="ChevronUp" />


### PR DESCRIPTION
## Changes Made
- Added back to top button to the mobile and desktop views throughout the whole webiste.

## Screenshots
<img width="1900" height="967" alt="image" src="https://github.com/user-attachments/assets/8be6d60a-4e43-4da4-b2a0-6d747fa15a8b" />
<img width="326" height="632" alt="image" src="https://github.com/user-attachments/assets/22d25ee4-bfbc-4acf-ad15-58b7b860dde7" />
