### PR TITLE
Fix FAQ Tab Visibility and Preserve Selected Category on Read More Navigation

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -138,6 +138,10 @@ const FaqPage = () => {
     }
   };
 
+  const activeCategoryIndex = Math.max(
+    FAQ_CATEGORY_OPTIONS.findIndex((option) => option.value === activeCategory),
+    0,
+  );
   const leftColumn = faqs.filter((_, i) => i % 2 === 0);
   const rightColumn = faqs.filter((_, i) => i % 2 !== 0);
 
@@ -161,12 +165,20 @@ const FaqPage = () => {
 
       <div className="mx-auto max-w-7xl px-4 py-8 sm:py-12 lg:px-10 rounded-3xl bg-lightgrey">
         <Tabs value={activeCategory} onValueChange={handleCategoryChange}>
-          <TabsList className="mx-auto mb-8 flex h-auto w-full max-w-md rounded-2xl bg-white p-1 shadow-sm">
+          <TabsList className="relative isolate mx-auto mb-8 flex h-auto w-full max-w-md overflow-hidden rounded-2xl border border-blue-200 bg-blue-50 p-1 shadow-sm">
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-1 left-1 z-0 rounded-xl bg-blue-600 shadow-md shadow-blue-600/20 transition-transform duration-300 ease-out"
+              style={{
+                width: `calc((100% - 0.5rem) / ${FAQ_CATEGORY_OPTIONS.length})`,
+                transform: `translateX(${activeCategoryIndex * 100}%)`,
+              }}
+            />
             {FAQ_CATEGORY_OPTIONS.map((option) => (
               <TabsTrigger
                 key={option.value}
                 value={option.value}
-                className="!m-0 flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold text-gray-600 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-sm"
+                className="relative z-10 !m-0 flex-1 rounded-xl bg-transparent px-4 py-2.5 text-sm font-bold text-blue-700 shadow-none transition-colors duration-200 hover:bg-white/70 hover:text-blue-800 data-[state=active]:bg-transparent data-[state=active]:text-white data-[state=active]:shadow-none"
               >
                 {option.label}
               </TabsTrigger>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -5,11 +5,14 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   DEFAULT_FAQ_CATEGORY,
   FAQ_CATEGORY_OPTIONS,
+  FAQ_CATEGORY_QUERY_PARAM,
+  isFaqCategory,
   type FaqCategory,
 } from "@/lib/faq-categories";
 import { useFetchFaqsQuery } from "@/store/api/splits/faqs";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
-import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 
@@ -88,9 +91,14 @@ const FaqSkeleton = () => (
   </div>
 );
 
-const FaqPage = () => {
+const FaqPageContent = () => {
+  const searchParams = useSearchParams();
+  const selectedCategoryParam = searchParams.get(FAQ_CATEGORY_QUERY_PARAM);
+  const selectedCategory = isFaqCategory(selectedCategoryParam)
+    ? selectedCategoryParam
+    : DEFAULT_FAQ_CATEGORY;
   const [activeCategory, setActiveCategory] =
-    useState<FaqCategory>(DEFAULT_FAQ_CATEGORY);
+    useState<FaqCategory>(selectedCategory);
   const [page, setPage] = useState(1);
   const [faqs, setFaqs] = useState<FaqItem[]>([]);
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -108,6 +116,10 @@ const FaqPage = () => {
     setFaqs([]);
     setOpenIndex(null);
   }, [activeCategory]);
+
+  useEffect(() => {
+    setActiveCategory(selectedCategory);
+  }, [selectedCategory]);
 
   useEffect(() => {
     if (!data?.results) return;
@@ -259,5 +271,11 @@ const FaqPage = () => {
     </div>
   );
 };
+
+const FaqPage = () => (
+  <Suspense fallback={null}>
+    <FaqPageContent />
+  </Suspense>
+);
 
 export default FaqPage;

--- a/src/components/home-page/faq/index.tsx
+++ b/src/components/home-page/faq/index.tsx
@@ -129,6 +129,11 @@ const Faqs = () => {
     setOpenIndex((prev) => (prev === index ? null : index));
   };
 
+  const activeCategoryIndex = Math.max(
+    FAQ_CATEGORY_OPTIONS.findIndex((option) => option.value === activeCategory),
+    0,
+  );
+
   return (
     <div className="px-4 pb-8 lg:px-8 lg:pb-12">
       <div
@@ -144,12 +149,20 @@ const Faqs = () => {
           onValueChange={handleCategoryChange}
           className="max-w-5xl mx-auto"
         >
-          <TabsList className="mx-auto mb-8 flex h-auto w-full max-w-md rounded-2xl bg-white/15 p-1 backdrop-blur">
+          <TabsList className="relative isolate mx-auto mb-8 flex h-auto w-full max-w-md overflow-hidden rounded-2xl border border-white/40 bg-blue-950/25 p-1 shadow-md shadow-blue-950/10 backdrop-blur">
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-1 left-1 z-0 rounded-xl bg-white shadow-lg shadow-blue-950/20 ring-1 ring-white transition-transform duration-300 ease-out"
+              style={{
+                width: `calc((100% - 0.5rem) / ${FAQ_CATEGORY_OPTIONS.length})`,
+                transform: `translateX(${activeCategoryIndex * 100}%)`,
+              }}
+            />
             {FAQ_CATEGORY_OPTIONS.map((option) => (
               <TabsTrigger
                 key={option.value}
                 value={option.value}
-                className="flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold text-white/75 data-[state=active]:bg-white data-[state=active]:text-blue-700 data-[state=active]:shadow-sm"
+                className="relative z-10 !m-0 flex-1 rounded-xl bg-transparent px-4 py-2.5 text-sm font-bold text-white drop-shadow-sm shadow-none transition-colors duration-200 hover:bg-white/10 hover:text-white data-[state=active]:bg-transparent data-[state=active]:text-faqblue data-[state=active]:drop-shadow-none data-[state=active]:shadow-none"
               >
                 {option.label}
               </TabsTrigger>

--- a/src/components/home-page/faq/index.tsx
+++ b/src/components/home-page/faq/index.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   DEFAULT_FAQ_CATEGORY,
   FAQ_CATEGORY_OPTIONS,
+  FAQ_CATEGORY_QUERY_PARAM,
   type FaqCategory,
 } from "@/lib/faq-categories";
 import { useFetchFaqsQuery } from "@/store/api/splits/faqs";
@@ -218,7 +219,10 @@ const Faqs = () => {
         {!isFetching && totalItems > 0 && (
           <div className="text-center mt-8">
             <Link
-              href="/faq"
+              href={{
+                pathname: "/faq",
+                query: { [FAQ_CATEGORY_QUERY_PARAM]: activeCategory },
+              }}
               className="inline-block px-8 py-3 border-2 border-white text-white text-base font-semibold rounded-xl hover:bg-white hover:text-blue-600 transition-all duration-300"
             >
               Read More

--- a/src/lib/faq-categories.ts
+++ b/src/lib/faq-categories.ts
@@ -3,6 +3,7 @@ export const FAQ_CATEGORY_VALUES = ["for_parents", "for_tutors"] as const;
 export type FaqCategory = (typeof FAQ_CATEGORY_VALUES)[number];
 
 export const DEFAULT_FAQ_CATEGORY: FaqCategory = "for_parents";
+export const FAQ_CATEGORY_QUERY_PARAM = "category";
 
 export const FAQ_CATEGORY_OPTIONS: Array<{
   value: FaqCategory;
@@ -11,3 +12,6 @@ export const FAQ_CATEGORY_OPTIONS: Array<{
   { value: "for_parents", label: "For Parents" },
   { value: "for_tutors", label: "For Tutors" },
 ];
+
+export const isFaqCategory = (value: string | null): value is FaqCategory =>
+  FAQ_CATEGORY_VALUES.includes(value as FaqCategory);


### PR DESCRIPTION
## Ticket
[TM-959](https://softvilmedia-team.atlassian.net/browse/TM-959)  
[TM-960](https://softvilmedia-team.atlassian.net/browse/TM-960)

## Summary
Fixes FAQ tab UX issues and preserves the selected FAQ category when navigating from the Home page FAQ section to the FAQ page.

## Changes

### Frontend
* Improved FAQ tab active/inactive visual states for clearer selection feedback.
* Added smooth active tab indicator movement between `For Parents` and `For Tutors`.
* Updated Home FAQ `Read More` link to include the currently active category.
* Updated FAQ page to initialize the selected tab from the category query param.

### Backend
* No backend changes in this PR.

## Files Changed
* `src/app/faq/page.tsx`
* `src/components/home-page/faq/index.tsx`
* `src/lib/faq-categories.ts`

## Root Cause
* FAQ tabs relied on weak direct active-state styling, making selected and unselected states unclear.
* The Home FAQ `Read More` link always navigated to `/faq` without passing the active tab/category, so the FAQ page defaulted to `For Parents`.

## Result
* Users can clearly identify the selected FAQ tab.
* Tab switching feels smoother and more polished.
* Clicking `Read More` from `For Tutors` opens the FAQ page with `For Tutors` selected.
* Clicking `Read More` from `For Parents` opens the FAQ page with `For Parents` selected.
