### PR TITLE
fix: blogs page scroll behavior and skeleton loader TM-951, TM-952

### DIFF
--- a/src/app/blogs/components/ViewBlogs.tsx
+++ b/src/app/blogs/components/ViewBlogs.tsx
@@ -58,16 +58,65 @@ export default function BlogsDashboard() {
 
   if (isBlogsLoading || isTagsLoading)
     return (
-      <div className="p-6 flex flex-col gap-6">
-        <Skeleton className="h-40 w-full rounded-xl" />
-        <div className="flex gap-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-8 w-20 rounded-full" />
+      <div className="flex flex-col gap-6">
+        {/* Hero banner skeleton */}
+        <div className="relative h-44 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl px-8 py-6 flex flex-col justify-center overflow-hidden">
+          <div className="absolute -right-8 -top-8 w-40 h-40 rounded-full bg-white/10" />
+          <div className="absolute -right-4 bottom-0 w-24 h-24 rounded-full bg-white/5" />
+          <div className="relative z-10 flex flex-col gap-3">
+            <Skeleton className="h-3 w-40 rounded bg-white/30" />
+            <Skeleton className="h-7 w-72 rounded bg-white/30" />
+            <Skeleton className="h-4 w-56 rounded bg-white/20" />
+          </div>
+        </div>
+
+        {/* Tag pills skeleton */}
+        <div className="flex flex-wrap gap-4">
+          <div className="h-8 px-4 rounded-full bg-blue-600 flex items-center">
+            <span className="text-sm font-semibold invisible">All</span>
+          </div>
+          {["Study Tips", "G.C.E A/L", "G.C.E O/L", "Tutor", "Parents"].map((tag) => (
+            <Skeleton key={tag} className="h-8 rounded-full">
+              <span className="text-sm font-semibold px-4 invisible">{tag}</span>
+            </Skeleton>
           ))}
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-64 w-full rounded-xl" />
+
+        {/* Blog card skeletons matching real card layout */}
+        <div className="grid gap-7 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-white border border-gray-100 rounded-2xl shadow-sm overflow-hidden flex flex-col"
+            >
+              {/* Cover image area with icon placeholder */}
+              <div className="relative h-44 bg-gray-100 flex items-center justify-center">
+                <svg className="w-10 h-10 text-gray-300" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5M21 12V6.75A2.25 2.25 0 0018.75 4.5H5.25A2.25 2.25 0 003 6.75V12" />
+                </svg>
+              </div>
+
+              {/* Card body */}
+              <div className="p-4 flex flex-col gap-3">
+                {/* Author row */}
+                <div className="flex items-center gap-2.5">
+                  <Skeleton className="h-7 w-7 rounded-full shrink-0" />
+                  <Skeleton className="h-3 w-24 rounded" />
+                </div>
+
+                <hr className="border-gray-100" />
+
+                {/* Title */}
+                <Skeleton className="h-4 w-full rounded" />
+                <Skeleton className="h-4 w-3/4 rounded" />
+
+                <hr className="border-gray-100" />
+
+                {/* Excerpt */}
+                <Skeleton className="h-3 w-full rounded" />
+                <Skeleton className="h-3 w-5/6 rounded" />
+              </div>
+            </div>
           ))}
         </div>
       </div>

--- a/src/app/blogs/components/table-of-content/TableOfContent.tsx
+++ b/src/app/blogs/components/table-of-content/TableOfContent.tsx
@@ -46,9 +46,18 @@ const TableOfContents = ({ html }: { html: string }) => {
 
   const scrollToHeading = (id: string) => {
     const el = document.getElementById(id);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
+    if (!el) return;
+    document.documentElement.style.scrollBehavior = "auto";
+    const start = window.scrollY;
+    const target = el.getBoundingClientRect().top + window.scrollY - 80;
+    const startTime = performance.now();
+    const step = () => {
+      const progress = Math.min((performance.now() - startTime) / 2000, 1);
+      window.scrollTo(0, start + (target - start) * progress);
+      if (progress < 1) requestAnimationFrame(step);
+      else document.documentElement.style.scrollBehavior = "";
+    };
+    step();
   };
 
   if (headings.length === 0) return null;


### PR DESCRIPTION
## Tickets
TM-951 | TM-952

## Summary
Fixes aggressive scroll behavior on the Blog Details page table of contents
and adds a structured skeleton loader to the Blogs listing page.

## Changes

**TM-951 — Aggressive auto-scroll on Blog Details table of contents**
- Replaced `scrollIntoView({ behavior: "smooth" })` with a custom
  `requestAnimationFrame` animation loop at 2000ms linear speed
- Root cause: `scroll-behavior: smooth !important` in globals.css was
  double-smoothing every animation frame causing a slow/laggy start
- Fix: temporarily override scroll-behavior to `auto` before animation,
  restore after completion
- Added 80px navbar offset to prevent headings hiding under fixed header

**TM-952 — Missing skeleton loader on Blogs page**
- Replaced generic flat skeleton with layout-accurate skeleton matching
  the real page structure
- Hero banner preserves gradient background with shimmer lines for label,
  title and subtitle
- Tab pills match real tag sizes using invisible text sizing, "All" shown
  in blue active state
- 9 blog card skeletons (matching pageSize) with image placeholder,
  author avatar, title lines, and excerpt lines

## Files Changed
- `src/app/blogs/components/table-of-content/TableOfContent.tsx`
- `src/app/blogs/components/ViewBlogs.tsx`

## Root Cause
- TM-951: Global `scroll-behavior: smooth !important` conflicted with
  custom JS scroll animation causing double-smoothing on every frame
- TM-952: Existing skeleton was a non-matching placeholder that did not
  reflect the actual blog page layout

## Result
- Blog Details table of contents scrolls smoothly at controlled speed
  with no aggressive jump or delayed start
- Blogs page displays a structured skeleton that closely matches the
  real layout during loading

## Checklist
- [ ] TM-951: Click table of contents items on any blog detail page and verify smooth controlled scroll
- [ ] TM-951: Verify heading is visible below navbar after scroll
- [ ] TM-952: Load blogs page on slow network and verify skeleton matches layout
- [ ] TM-952: Verify skeleton shows hero, tabs, and 9 card placeholders