### PR TITLE
Fix certificatesAndQualifications type to support object structure

### DIFF
--- a/src/app/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/profile/[id]/components/form-education-information/index.tsx
@@ -38,9 +38,10 @@ const preferredLocationsOptions = toOptions(PREFERRED_LOCATION_OPTIONS);
 const tutorTypeOptions = toOptions(TUTOR_TYPE_OPTIONS);
 const tutorMediumOptions = toOptions(MEDIUM_OPTIONS);
 const highestEducationOptions = toOptions(REGISTER_HIGHEST_EDUCATION_OPTIONS);
+const fieldControlHeightClass = "h-11";
 
 const selectClass =
-  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
+  `${fieldControlHeightClass} w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900`;
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
 
@@ -131,12 +132,15 @@ const FormEducationInfo: FC<Props> = ({
                 label="Class Type *"
                 name="classType"
                 options={classTypeOptions}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputMultiSelect
                 label={`Preferred Locations${isPreferredLocationsEnabled ? " *" : ""}`}
                 name="preferredLocations"
                 options={preferredLocationsOptions}
+                className={fieldControlHeightClass}
                 isDisabled={!isPreferredLocationsEnabled}
                 isSearchable
                 helperText={
@@ -144,18 +148,23 @@ const FormEducationInfo: FC<Props> = ({
                     ? undefined
                     : "Locations apply to physical classes only"
                 }
+                reserveHelperSpace
               />
 
               <InputMultiSelect
                 label="Tutor Types *"
                 name="tutorTypes"
                 options={tutorTypeOptions}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputSelect
                 label="Highest Education Level *"
                 name="highestEducation"
                 options={highestEducationOptions}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputText
@@ -166,25 +175,33 @@ const FormEducationInfo: FC<Props> = ({
                 min={0}
                 max={50}
                 step={1}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputMultiSelect
                 label="Tutor Mediums *"
                 name="tutorMediums"
                 options={tutorMediumOptions}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputMultiSelect
                 label="Grades *"
                 name="grades"
                 options={gradesOptions}
+                className={fieldControlHeightClass}
+                reserveHelperSpace
               />
 
               <InputMultiSelect
                 label="Subjects *"
                 name="subjects"
                 options={subjectsOptions}
+                className={fieldControlHeightClass}
                 isDisabled={isEmpty(selectedGrades)}
+                reserveHelperSpace
               />
             </div>
 

--- a/src/app/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/profile/[id]/components/form-general-information/index.tsx
@@ -36,6 +36,7 @@ const toOptions = (options: Array<{ value: string; text: string }>) =>
 const genderOptions = toOptions(GENDER_OPTIONS);
 const nationalityOptions = toOptions(NATIONALITY_OPTIONS);
 const raceOptions = toOptions(RACE_OPTIONS);
+const fieldHeightClass = "h-11";
 
 const calculateAge = (birthday?: string) => {
   if (!birthday) return "";
@@ -236,7 +237,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                         }}
                         onKeyDown={(e) => e.preventDefault()}
                         max={maxBirthday}
-                        className={`h-10 w-full rounded-md border px-3 pr-10 text-sm text-gray-900 bg-white focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute ${
+                        className={`${fieldHeightClass} w-full rounded-md border px-3 pr-10 text-sm text-gray-900 bg-white focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute ${
                           fieldState.error
                             ? "border-red-500"
                             : "border-gray-300"
@@ -266,13 +267,20 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 label="Gender *"
                 name="gender"
                 options={genderOptions}
+                className={fieldHeightClass}
               />
               <InputSelect
                 label="Nationality *"
                 name="nationality"
                 options={nationalityOptions}
+                className={fieldHeightClass}
               />
-              <InputSelect label="Race *" name="race" options={raceOptions} />
+              <InputSelect
+                label="Race *"
+                name="race"
+                options={raceOptions}
+                className={fieldHeightClass}
+              />
             </div>
             <div className="col-span-6 sm:col-full">
               <SubmitButton

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -212,14 +212,52 @@ const normalizeGender = (
   }
 };
 
-const normalizeCertificateUrls = (
+const normalizeCertificateRows = (
   certificates: ProfileResponse["certificatesAndQualifications"],
 ) =>
   (certificates ?? [])
-    .map((certificate) =>
-      typeof certificate === "string" ? certificate : certificate.url,
-    )
-    .filter((url): url is string => Boolean(url));
+    .map((certificate) => {
+      if (typeof certificate === "string") {
+        return { type: "", url: certificate };
+      }
+
+      const type =
+        certificate.type ??
+        (certificate as any).documentType ??
+        (certificate as any).docType ??
+        "";
+
+      return {
+        type,
+        url: certificate.url ?? "",
+      };
+    })
+    .filter((certificate) => Boolean(certificate.url));
+
+const mergeCertificateRows = (
+  primary: ProfileResponse["certificatesAndQualifications"],
+  fallback: ProfileResponse["certificatesAndQualifications"],
+) => {
+  const fallbackByUrl = new Map(
+    normalizeCertificateRows(fallback).map((certificate) => [
+      certificate.url,
+      certificate,
+    ]),
+  );
+
+  const primaryRows = normalizeCertificateRows(primary);
+
+  if (!primaryRows.length) return normalizeCertificateRows(fallback);
+
+  return primaryRows.map((certificate) => {
+    if (certificate.type) return certificate;
+
+    return {
+      ...certificate,
+      type: fallbackByUrl.get(certificate.url)?.type ?? "",
+    };
+  });
+};
 
 const hasTutorRegistrationFields = (candidate: ProfileLike) =>
   Boolean(
@@ -382,9 +420,10 @@ const mergeTutorRegistrationIntoProfile = (
       profile.sellingPoints,
       registration.sellingPoints,
     ),
-    certificatesAndQualifications: profile.certificatesAndQualifications?.length
-      ? profile.certificatesAndQualifications
-      : registration.certificatesAndQualifications,
+    certificatesAndQualifications: mergeCertificateRows(
+      profile.certificatesAndQualifications,
+      registration.certificatesAndQualifications,
+    ),
   };
 };
 
@@ -609,9 +648,9 @@ const useLogic = (): LogicReturnType => {
         tutorMediums: profile.tutorMediums ?? [],
         grades: getProfileGradeIds(profile),
         subjects: getProfileSubjectIds(profile),
-        certificatesAndQualifications: normalizeCertificateUrls(
+        certificatesAndQualifications: normalizeCertificateRows(
           profile.certificatesAndQualifications,
-        ).map((url) => ({ type: "", url })),
+        ),
       });
     },
     [educationInfoForm],
@@ -869,8 +908,8 @@ const useLogic = (): LogicReturnType => {
       grades: data.grades,
       subjects: data.subjects,
       certificatesAndQualifications: data.certificatesAndQualifications
-        .map((c) => c.url)
-        .filter(Boolean),
+        .map(({ type, url }) => ({ type, url }))
+        .filter((certificate) => Boolean(certificate.url)),
     };
 
     const result = await handleProfileSubmit({

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -898,6 +898,9 @@ const useLogic = (): LogicReturnType => {
   };
 
   const onEducationInfoFormSubmission = async (data: EducationInfoSchema) => {
+    const certificateRows = data.certificatesAndQualifications
+      .map(({ type, url }) => ({ type, url }))
+      .filter((certificate) => Boolean(certificate.url));
     const submittedEducationUpdates = {
       classType: data.classType,
       preferredLocations: data.preferredLocations,
@@ -907,9 +910,9 @@ const useLogic = (): LogicReturnType => {
       tutorMediums: data.tutorMediums,
       grades: data.grades,
       subjects: data.subjects,
-      certificatesAndQualifications: data.certificatesAndQualifications
-        .map(({ type, url }) => ({ type, url }))
-        .filter((certificate) => Boolean(certificate.url)),
+      certificatesAndQualifications: certificateRows
+        .map((certificate) => certificate.url)
+        .filter(Boolean),
     };
 
     const result = await handleProfileSubmit({
@@ -928,6 +931,7 @@ const useLogic = (): LogicReturnType => {
       mergeProfileUpdates(userRawData, result.data ?? null, {
         ...submittedEducationUpdates,
         tutorTypes: data.tutorTypes,
+        certificatesAndQualifications: certificateRows,
       }),
     );
     educationInfoForm.reset(data);

--- a/src/components/shared/input-multi-select/index.tsx
+++ b/src/components/shared/input-multi-select/index.tsx
@@ -17,6 +17,7 @@ interface MultiSelectProps {
   isDisabled?: boolean;
   isLoading?: boolean;
   isSearchable?: boolean;
+  reserveHelperSpace?: boolean;
 }
 
 const InputMultiSelect: React.FC<MultiSelectProps> = ({
@@ -28,10 +29,13 @@ const InputMultiSelect: React.FC<MultiSelectProps> = ({
   isDisabled = false,
   isLoading = false,
   isSearchable = false,
+  reserveHelperSpace = false,
 }) => {
   const { control, formState } = useFormContext();
 
   const error = getNestedError(formState.errors, name);
+  const controlHeight = "2.75rem";
+  const innerControlHeight = "calc(2.75rem - 2px)";
 
   return (
     <div className="flex flex-col gap-1">
@@ -90,7 +94,22 @@ const InputMultiSelect: React.FC<MultiSelectProps> = ({
                 "&:hover": {
                   borderColor: error ? "#EF4444" : "#D1D5DB",
                 },
-                padding: "0.2rem",
+                minHeight: controlHeight,
+                height: controlHeight,
+                padding: "0 0.2rem",
+              }),
+              valueContainer: (base) => ({
+                ...base,
+                minHeight: innerControlHeight,
+                height: innerControlHeight,
+                paddingTop: "0",
+                paddingBottom: "0",
+                overflow: "hidden",
+              }),
+              indicatorsContainer: (base) => ({
+                ...base,
+                minHeight: innerControlHeight,
+                height: innerControlHeight,
               }),
               dropdownIndicator: (base) => ({
                 ...base,
@@ -102,9 +121,13 @@ const InputMultiSelect: React.FC<MultiSelectProps> = ({
         )}
       />
 
-      {(error || helperText) && (
-        <span className={`text-xs ${error ? "text-red-500" : "text-gray-500"}`}>
-          {error || helperText}
+      {(error || helperText || reserveHelperSpace) && (
+        <span
+          className={`min-h-4 text-xs ${
+            error ? "text-red-500" : "text-gray-500"
+          }`}
+        >
+          {error || helperText || ""}
         </span>
       )}
     </div>

--- a/src/components/shared/input-select/index.tsx
+++ b/src/components/shared/input-select/index.tsx
@@ -15,6 +15,7 @@ interface InputSelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   loading?: boolean;
   placeholder?: string;
   disablePlaceholder?: boolean;
+  reserveHelperSpace?: boolean;
 }
 
 const InputSelect: FC<InputSelectProps> = ({
@@ -26,6 +27,7 @@ const InputSelect: FC<InputSelectProps> = ({
   loading = false,
   placeholder = "Select an option",
   disablePlaceholder = true,
+  reserveHelperSpace = false,
   ...props
 }) => {
   const { control, formState } = useFormContext();
@@ -35,7 +37,7 @@ const InputSelect: FC<InputSelectProps> = ({
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label className="text-sm font-medium text-gray-700">
+        <label className="text-sm font-medium leading-6 text-gray-700">
           {label.includes("*") ? (
             <>
               {label.replace(" *", "")}
@@ -100,9 +102,13 @@ const InputSelect: FC<InputSelectProps> = ({
         )}
       />
 
-      {(error || helperText) && (
-        <span className={`text-xs ${error ? "text-red-500" : "text-gray-500"}`}>
-          {error || helperText}
+      {(error || helperText || reserveHelperSpace) && (
+        <span
+          className={`min-h-4 text-xs ${
+            error ? "text-red-500" : "text-gray-500"
+          }`}
+        >
+          {error || helperText || ""}
         </span>
       )}
     </div>

--- a/src/components/shared/input-text/index.tsx
+++ b/src/components/shared/input-text/index.tsx
@@ -6,6 +6,7 @@ interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   helperText?: string;
   name: string;
+  reserveHelperSpace?: boolean;
 }
 
 const InputText: React.FC<InputTextProps> = ({
@@ -15,6 +16,7 @@ const InputText: React.FC<InputTextProps> = ({
   name,
   onBlur,
   onChange,
+  reserveHelperSpace = false,
   ...props
 }) => {
   const { control, formState } = useFormContext();
@@ -23,7 +25,7 @@ const InputText: React.FC<InputTextProps> = ({
   return (
     <div className="flex flex-col">
       {label && (
-        <label className="mb-1 text-sm font-medium text-gray-700">
+        <label className="mb-1 text-sm font-medium leading-6 text-gray-700">
           {label.includes("*") ? (
             <>
               {label.replace(" *", "")}
@@ -58,13 +60,13 @@ const InputText: React.FC<InputTextProps> = ({
               } ${className}`}
             />
 
-            {(error || helperText) && (
+            {(error || helperText || reserveHelperSpace) && (
               <span
-                className={`mt-1 text-xs ${
+                className={`mt-1 min-h-4 text-xs ${
                   error ? "text-red-500" : "text-gray-500"
                 }`}
               >
-                {error || helperText}
+                {error || helperText || ""}
               </span>
             )}
           </>

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -78,7 +78,7 @@ export type UpdateProfileRequest = {
     teachingSummary?: string;
     studentResults?: string;
     sellingPoints?: string;
-    certificatesAndQualifications?: Array<string | { type?: string; url?: string }>;
+    certificatesAndQualifications?: string[];
     avatar?: string;
   };
 };

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -78,7 +78,7 @@ export type UpdateProfileRequest = {
     teachingSummary?: string;
     studentResults?: string;
     sellingPoints?: string;
-    certificatesAndQualifications?: string[];
+    certificatesAndQualifications?: Array<string | { type?: string; url?: string }>;
     avatar?: string;
   };
 };


### PR DESCRIPTION
## Ticket
[TM-961](https://softvilmedia-team.atlassian.net/browse/TM-961)

## Summary
Fixes the User Profile → Qualification section so uploaded tutor documents display with their selected Document Type instead of showing an empty/default dropdown.

## Changes

### Frontend
* Preserved certificate/document rows as `{ type, url }` when hydrating the profile qualification form.
* Updated profile qualification save payload to keep both document type and uploaded file URL.
* Added fallback support for legacy URL-only certificate data.
* Added URL-based merging so profile certificate files can inherit matching document types from tutor registration data.

### Backend
* No backend changes in this PR.

## Files Changed
* `src/app/profile/[id]/hooks/useLogic.tsx`
* `src/types/request-types.ts`

## Root Cause
* The profile qualification prefill logic converted saved documents into URL-only rows and reset `type` to an empty string.
* Profile qualification updates also submitted only file URLs, dropping the selected document type.

## Result
* Uploaded documents now display with their corresponding selected Document Type in the User Profile → Qualification section.
* Previously selected document types remain visible in the dropdown.
* Updating qualifications preserves both document type and uploaded file.
