### PR TITLE
feat: show Pearson redirect notice for Edexcel OL/AL past papers

### DIFF
--- a/src/app/past-exam-papers/hooks/useLogic.tsx
+++ b/src/app/past-exam-papers/hooks/useLogic.tsx
@@ -165,6 +165,7 @@ type LogicReturnType = {
     isSubjectsLoading: boolean;
     isPapersLoading: boolean;
     papers: Paper[];
+    isEdexcelGradeSelected: boolean;
   };
 };
 
@@ -290,6 +291,11 @@ const useLogic = (): LogicReturnType => {
     return matchesSearch && matchesGrade && matchesSubject && matchesMedium;
   });
 
+  const isEdexcelGradeSelected = !!selectedGrade &&
+    gradesOptions.some(
+      (g) => g.value === selectedGrade && /edexcel/i.test(g.label),
+    );
+
   return {
     forms: {
       testPaperSearchForm,
@@ -302,6 +308,7 @@ const useLogic = (): LogicReturnType => {
       isSubjectsLoading: isPapersLoading,
       isPapersLoading,
       papers: filteredPapers,
+      isEdexcelGradeSelected,
     },
   };
 };

--- a/src/app/past-exam-papers/page.tsx
+++ b/src/app/past-exam-papers/page.tsx
@@ -4,6 +4,39 @@ import FormTestPaperSearch from "./components/form-test-papper-search";
 import TestPaperList from "./components/test-papper-list";
 import useLogic from "./hooks/useLogic";
 import WhatsAppButton from "@/components/shared/whatapp-button";
+import { ExternalLink } from "lucide-react";
+
+const PEARSON_URL =
+  "https://qualifications.pearson.com/en/support/support-topics/exams/past-papers.html";
+
+const EdexcelRedirectNotice = () => (
+  <div className="max-w-7xl mx-auto mt-8 px-4">
+    <div className="bg-white rounded-3xl p-8 sm:p-12 shadow-sm border border-gray-100">
+      <div className="max-w-2xl">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">
+          Edexcel Past Papers
+        </h3>
+        <p className="text-gray-600 text-sm leading-relaxed mb-3">
+          Due to copyright restrictions, we are unable to share Edexcel past
+          papers on our website.
+        </p>
+        <p className="text-gray-600 text-sm leading-relaxed">
+          However, you can access all official past papers directly through the
+          Pearson Edexcel website.{" "}
+          <a
+            href={PEARSON_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-blue-600 font-semibold hover:underline"
+          >
+            Access here: Pearson Edexcel Past Papers
+            <ExternalLink size={14} />
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+);
 
 const TestPapers = () => {
   const {
@@ -15,6 +48,7 @@ const TestPapers = () => {
       isSubjectsLoading,
       papers: availablePapers,
       isPapersLoading,
+      isEdexcelGradeSelected,
     },
     forms: { testPaperSearchForm },
   } = useLogic();
@@ -49,10 +83,14 @@ const TestPapers = () => {
         />
       </div>
 
-      <TestPaperList
-        availablePapers={availablePapers}
-        isPapersLoading={isPapersLoading}
-      />
+      {isEdexcelGradeSelected ? (
+        <EdexcelRedirectNotice />
+      ) : (
+        <TestPaperList
+          availablePapers={availablePapers}
+          isPapersLoading={isPapersLoading}
+        />
+      )}
       <WhatsAppButton />
     </div>
   );


### PR DESCRIPTION
## Summary
- When Edexcel OL or Edexcel AL is selected in the past papers grade filter, the paper
  list is replaced with a copyright notice linking to the official Pearson Edexcel website
- All other grades are unaffected — papers load and filter as before
- Detection is label-based (/edexcel/i regex) so it works for any Edexcel grade added in future

## Test Plan
- [ ] Select "Edexcel OL" grade → copyright notice appears with Pearson link
- [ ] Select "Edexcel AL" grade → copyright notice appears with Pearson link
- [ ] Click the Pearson link → opens Pearson Edexcel past papers page in a new tab
- [ ] Select any other grade (e.g. G.C.E O/L, G.C.E A/L) → papers list renders normally
- [ ] Select no grade → papers list renders normally
- [ ] Switch from Edexcel grade to a normal grade → notice disappears, papers appear
