### PR TITLE
feat: improve blog table of contents scroll animation

### DIFF
--- a/src/app/blogs/components/table-of-content/TableOfContent.tsx
+++ b/src/app/blogs/components/table-of-content/TableOfContent.tsx
@@ -50,10 +50,12 @@ const TableOfContents = ({ html }: { html: string }) => {
     document.documentElement.style.scrollBehavior = "auto";
     const start = window.scrollY;
     const target = el.getBoundingClientRect().top + window.scrollY - 80;
+    const duration = 600;
     const startTime = performance.now();
     const step = () => {
-      const progress = Math.min((performance.now() - startTime) / 2000, 1);
-      window.scrollTo(0, start + (target - start) * progress);
+      const progress = Math.min((performance.now() - startTime) / duration, 1);
+      const ease = 1 - Math.pow(1 - progress, 3);
+      window.scrollTo(0, start + (target - start) * ease);
       if (progress < 1) requestAnimationFrame(step);
       else document.documentElement.style.scrollBehavior = "";
     };


### PR DESCRIPTION
## Summary
- Replaced slow 2000ms linear scroll with a 600ms ease-out cubic animation 
  in the Blog Detail page Table of Contents
- Scroll now starts immediately and fast on click, then decelerates smoothly 
  into the target heading — eliminating the perceived holding delay

## Test Plan
- [ ] Open any blog detail page with a Table of Contents
- [ ] Click any heading link → scroll starts instantly with no delay
- [ ] Scroll should decelerate smoothly as it reaches the target heading
- [ ] Clicking multiple headings in quick succession should work correctly
