### PR TITLE
feat: add Home link to main navigation menu

### DIFF
--- a/src/components/shared/navbar/drawer-content.tsx
+++ b/src/components/shared/navbar/drawer-content.tsx
@@ -12,6 +12,7 @@ interface NavigationItem {
 }
 
 const navigation: NavigationItem[] = [
+  { name: "Home", href: "/" },
   { name: "Request for Tutor", href: "/request-for-tutors" },
   { name: "Register as a Tutor", href: "/register-tutor" },
   {

--- a/src/components/shared/navbar/header.tsx
+++ b/src/components/shared/navbar/header.tsx
@@ -20,6 +20,7 @@ interface NavigationItem {
 }
 
 const navigation: NavigationItem[] = [
+  { name: "Home", href: "/" },
   { name: "Request for Tutor", href: "/request-for-tutors" },
   { name: "Register as a Tutor", href: "/register-tutor" },
   {


### PR DESCRIPTION
## Summary
- Added "Home" as the first navigation item in the desktop navbar
- Added "Home" as the first navigation item in the mobile drawer menu
- Home link correctly highlights as active only when on the / route
- Resolves confusion for users who could not find a way back to the landing page

## Test Plan
- [ ] Desktop — Home link appears as first item in navbar
- [ ] Desktop — Home link highlights blue when on the home page
- [ ] Desktop — Home link navigates correctly to /
- [ ] Mobile — Home link appears as first item in drawer menu
- [ ] Mobile — Home link highlights blue when on the home page
- [ ] Switching between pages — active state updates correctly