### PR TITLE
fix: Updated the tuition rates page to load grade counts first using the grades-with-counts endpoint

### DIFF
--- a/src/app/tuition-rates/components/all-tuition-rates.tsx
+++ b/src/app/tuition-rates/components/all-tuition-rates.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefCallback } from "react";
 import { BookOpen, ChevronDown } from "lucide-react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import {
@@ -8,11 +9,34 @@ import {
   AccordionContent,
   AccordionItem,
 } from "@/components/ui/accordion";
-import { useFetchGradesQuery } from "@/store/api/splits/grades";
-import { useFetchTuitionRatesQuery } from "@/store/api/splits/tuition-rates";
-import { Grade, TuitionRateItem } from "@/types/response-types";
+import {
+  useFetchGradesWithCountsQuery,
+  useFetchTuitionRatesByGradeQuery,
+} from "@/store/api/splits/tuition-rates";
+import { TuitionRateItem } from "@/types/response-types";
 
 type Rate = { minimumRate: string | number; maximumRate: string | number };
+type GradeWithCount = {
+  _id?: string;
+  id?: string;
+  title: string;
+  tuitionRateCount?: number;
+};
+type TuitionRatePagination = {
+  page: number;
+  totalPages: number;
+  totalResults: number;
+};
+
+const TUITION_RATES_PAGE_SIZE = 10;
+
+function getTuitionRateKey(rate: TuitionRateItem) {
+  return (
+    rate._id ||
+    (rate as { id?: string }).id ||
+    `${rate.grade?.id || "unknown-grade"}-${rate.subject?.id || "unknown-subject"}`
+  );
+}
 
 function formatRateValue(value: string | number) {
   const numericValue = typeof value === "number" ? value : Number(value);
@@ -46,7 +70,21 @@ function RateCell({ rate }: { rate?: Rate }) {
   );
 }
 
-function TuitionRateTable({ items }: { items: TuitionRateItem[] }) {
+function TuitionRateTable({
+  isInitialLoading,
+  items,
+}: {
+  isInitialLoading: boolean;
+  items: TuitionRateItem[];
+}) {
+  if (isInitialLoading) {
+    return (
+      <div className="flex items-center justify-center px-6 py-12">
+        <div className="w-8 h-8 rounded-full border-4 border-[#FCA627] border-t-transparent animate-spin" />
+      </div>
+    );
+  }
+
   if (!items.length) {
     return (
       <div className="px-6 py-12 text-center text-sm text-gray-500">
@@ -56,35 +94,37 @@ function TuitionRateTable({ items }: { items: TuitionRateItem[] }) {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full min-w-[920px] text-sm table-fixed">
+    <div className="w-full overflow-x-auto">
+      <table className="w-full min-w-[1120px] table-auto text-sm">
         <thead>
           <tr className="bg-gray-50 border-b border-gray-200">
-            <th className="text-left px-5 py-3 font-semibold text-gray-600 w-[24%] whitespace-nowrap">
+            <th className="text-left px-5 py-3 font-semibold text-gray-600 min-w-[220px] whitespace-nowrap">
               Subject
             </th>
-            <th className="text-left px-5 py-3 font-semibold text-gray-600 w-[19%] whitespace-nowrap">
+            <th className="text-left px-5 py-3 font-semibold text-gray-600 min-w-[220px] whitespace-nowrap">
               <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
                 <span className="w-2.5 h-2.5 rounded-full bg-[#28BBA3] inline-block" />
                 University Students
               </span>
             </th>
-            <th className="text-left px-5 py-3 font-semibold text-gray-600 w-[19%] whitespace-nowrap">
+            <th className="text-left px-5 py-3 font-semibold text-gray-600 min-w-[220px] whitespace-nowrap">
               <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
                 <span className="w-2.5 h-2.5 rounded-full bg-[#FCA627] inline-block" />
                 Part Time Tutor
               </span>
             </th>
-            <th className="text-left px-5 py-3 font-semibold text-gray-600 w-[19%] whitespace-nowrap">
+            <th className="text-left px-5 py-3 font-semibold text-gray-600 min-w-[220px] whitespace-nowrap">
               <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
                 <span className="w-2.5 h-2.5 rounded-full bg-[#EF4350] inline-block" />
                 Full Time Tutor
               </span>
             </th>
-            <th className="text-left px-5 py-3 font-semibold text-gray-600 w-[19%] whitespace-nowrap">
-              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+            <th className="text-left px-5 py-3 font-semibold text-gray-600 min-w-[240px]">
+              <span className="inline-flex items-start gap-1.5">
                 <span className="w-2.5 h-2.5 rounded-full bg-[#434eef] inline-block" />
-                Gov/International Teachers <br /> (Ex / Current)
+                <span className="leading-5">
+                  Gov/International Teachers <br /> (Ex / Current)
+                </span>
               </span>
             </th>
           </tr>
@@ -98,28 +138,28 @@ function TuitionRateTable({ items }: { items: TuitionRateItem[] }) {
                 idx % 2 === 0 ? "bg-white" : "bg-gray-50/60"
               }`}
             >
-              <td className="px-5 py-4 align-middle">
+              <td className="min-w-[220px] px-5 py-4 align-middle">
                 <span className="inline-flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-[#28BBA3] flex-shrink-0" />
-                  <span className="font-semibold text-gray-800 whitespace-nowrap">
+                  <span className="font-semibold text-gray-800">
                     {item.subject?.title || "Unknown Subject"}
                   </span>
                 </span>
               </td>
 
-              <td className="px-5 py-4 align-middle">
+              <td className="min-w-[220px] px-5 py-4 align-middle">
                 <RateCell rate={item.universityStudentsRate} />
               </td>
 
-              <td className="px-5 py-4 align-middle">
+              <td className="min-w-[220px] px-5 py-4 align-middle">
                 <RateCell rate={item.partTimeTutorRate} />
               </td>
 
-              <td className="px-5 py-4 align-middle">
+              <td className="min-w-[220px] px-5 py-4 align-middle">
                 <RateCell rate={item.fullTimeTutorRate} />
               </td>
 
-              <td className="px-5 py-4 align-middle">
+              <td className="min-w-[240px] px-5 py-4 align-middle">
                 <RateCell rate={item.moeTeacherRate} />
               </td>
             </tr>
@@ -130,62 +170,241 @@ function TuitionRateTable({ items }: { items: TuitionRateItem[] }) {
   );
 }
 
-export default function TuitionRatesByGrade() {
-  const [activeAccordion, setActiveAccordion] = useState<string | undefined>(
-    undefined,
+function GradeTuitionRatesItem({
+  grade,
+  itemValue,
+  isActive,
+  registerTrigger,
+}: {
+  grade: GradeWithCount;
+  itemValue: string;
+  isActive: boolean;
+  registerTrigger: RefCallback<HTMLButtonElement>;
+}) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [tuitionRates, setTuitionRates] = useState<TuitionRateItem[]>([]);
+  const [pagination, setPagination] = useState<TuitionRatePagination | null>(
+    null,
   );
-
-  const { data: gradesData, isLoading: isGradesLoading } = useFetchGradesQuery({
-    page: 1,
-    limit: 1000,
-  });
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const isRequestingNextPageRef = useRef(false);
+  const mergedPagesRef = useRef(new Set<number>());
+  const gradeId = grade.id || (grade as { _id?: string })._id;
 
   const {
     data: tuitionRatesData,
     isLoading: isRatesLoading,
+    isFetching: isRatesFetching,
     error,
-  } = useFetchTuitionRatesQuery({
-    page: 1,
-    limit: 1000,
-  });
-
-  const grades = useMemo(() => gradesData?.results || [], [gradesData]);
-  const tuitionRatesByGradeId = useMemo(() => {
-    return (tuitionRatesData?.results || []).reduce<
-      Record<string, TuitionRateItem[]>
-    >((acc, item) => {
-      const gradeId = item.grade?.id || "unknown";
-
-      if (!acc[gradeId]) {
-        acc[gradeId] = [];
-      }
-
-      acc[gradeId].push(item);
-      return acc;
-    }, {});
-  }, [tuitionRatesData]);
+  } = useFetchTuitionRatesByGradeQuery(
+    {
+      gradeId: gradeId || "",
+      page: currentPage,
+      limit: TUITION_RATES_PAGE_SIZE,
+    },
+    {
+      skip: !gradeId || !isActive || grade.tuitionRateCount === 0,
+    },
+  );
+  const hasMoreRates = pagination ? currentPage < pagination.totalPages : false;
+  const visibleCount =
+    grade.tuitionRateCount ?? pagination?.totalResults ?? tuitionRates.length;
 
   useEffect(() => {
-    if (grades.length > 0 && activeAccordion === undefined) {
-      setActiveAccordion(grades[0].id || "grade-0");
-    }
-  }, [grades, activeAccordion]);
+    setCurrentPage(1);
+    setTuitionRates([]);
+    setPagination(null);
+    isRequestingNextPageRef.current = false;
+    mergedPagesRef.current.clear();
+  }, [gradeId]);
 
-  if (isGradesLoading || isRatesLoading) {
+  useEffect(() => {
+    if (!tuitionRatesData) return;
+
+    const responsePage = tuitionRatesData.page || currentPage;
+
+    if (mergedPagesRef.current.has(responsePage)) {
+      isRequestingNextPageRef.current = false;
+      return;
+    }
+
+    mergedPagesRef.current.add(responsePage);
+    isRequestingNextPageRef.current = false;
+
+    setTuitionRates((prevRates) => {
+      const nextRates = tuitionRatesData.results || [];
+      const ratesById = new Map<string, TuitionRateItem>();
+
+      const ratesToMerge = responsePage === 1 ? nextRates : prevRates.concat(nextRates);
+
+      ratesToMerge.forEach((rate) => {
+        ratesById.set(getTuitionRateKey(rate), rate);
+      });
+
+      return Array.from(ratesById.values());
+    });
+
+    setPagination({
+      page: responsePage,
+      totalPages: tuitionRatesData.totalPages || currentPage,
+      totalResults: tuitionRatesData.totalResults || 0,
+    });
+  }, [currentPage, tuitionRatesData]);
+
+  const loadMoreRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+
+      if (!isActive) {
+        return;
+      }
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (
+          entries[0]?.isIntersecting &&
+          hasMoreRates &&
+          !isRatesFetching &&
+          !isRequestingNextPageRef.current
+        ) {
+          isRequestingNextPageRef.current = true;
+          setCurrentPage((page) => page + 1);
+        }
+      });
+
+      if (node) {
+        observerRef.current.observe(node);
+      }
+    },
+    [hasMoreRates, isActive, isRatesFetching],
+  );
+
+  return (
+    <AccordionItem
+      value={itemValue}
+      className="rounded-2xl overflow-hidden shadow-md border border-gray-100 bg-white"
+    >
+      <AccordionPrimitive.Header className="flex">
+        <AccordionPrimitive.Trigger
+          ref={registerTrigger}
+          className="flex w-full min-w-0 items-center justify-between gap-3 px-3 sm:px-5 py-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-left [&[data-state=open]_.chevron]:rotate-180"
+        >
+          <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+            <div className="bg-white/20 rounded-full p-1.5 shrink-0">
+              <BookOpen className="w-4 h-4 sm:w-5 sm:h-5 text-white" />
+            </div>
+
+            <h2 className="text-white font-bold text-base sm:text-lg tracking-wide min-w-0 truncate">
+              {grade.title}
+            </h2>
+          </div>
+
+          <div className="flex items-center gap-3 shrink-0">
+            <span className="inline-flex items-center bg-white/20 text-white text-xs font-semibold px-2.5 sm:px-3 py-1 rounded-full whitespace-nowrap">
+              {visibleCount} item
+              {visibleCount === 1 ? "" : "s"}
+            </span>
+
+            <ChevronDown className="chevron w-5 h-5 text-white shrink-0 transition-transform duration-300" />
+          </div>
+        </AccordionPrimitive.Trigger>
+      </AccordionPrimitive.Header>
+
+      <AccordionContent>
+        {error && tuitionRates.length === 0 ? (
+          <div className="px-6 py-12 text-center text-sm font-medium text-red-500">
+            Failed to load tuition rates for this grade.
+          </div>
+        ) : (
+          <>
+            <TuitionRateTable
+              isInitialLoading={
+                isRatesLoading &&
+                tuitionRates.length === 0 &&
+                grade.tuitionRateCount !== 0
+              }
+              items={tuitionRates}
+            />
+
+            <div
+              ref={loadMoreRef}
+              className="flex min-h-16 items-center justify-center py-5"
+            >
+              {isRatesFetching && tuitionRates.length > 0 ? (
+                <div className="flex items-center gap-3 text-sm font-medium text-gray-500">
+                  <div className="w-5 h-5 rounded-full border-2 border-[#FCA627] border-t-transparent animate-spin" />
+                  Loading more tuition rates...
+                </div>
+              ) : error ? (
+                <p className="text-sm font-medium text-red-500">
+                  Failed to load more tuition rates.
+                </p>
+              ) : hasMoreRates ? (
+                <span className="sr-only">Load more tuition rates</span>
+              ) : tuitionRates.length > 0 ? (
+                <p className="text-sm text-gray-400">
+                  Showing {tuitionRates.length}
+                  {pagination?.totalResults
+                    ? ` of ${pagination.totalResults}`
+                    : ""}{" "}
+                  tuition rates
+                </p>
+              ) : null}
+            </div>
+          </>
+        )}
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
+export default function TuitionRatesByGrade() {
+  const [activeAccordion, setActiveAccordion] = useState<string | undefined>(
+    undefined,
+  );
+  const triggerRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const { data: gradesData, isLoading: isGradesLoading } =
+    useFetchGradesWithCountsQuery();
+  const grades = useMemo(() => gradesData?.grades || [], [gradesData]);
+
+  useEffect(() => {
+    if (activeAccordion === undefined && grades.length > 0) {
+      const firstGrade = grades[0] as GradeWithCount;
+      setActiveAccordion(firstGrade.id || firstGrade._id || "grade-0");
+    }
+  }, [activeAccordion, grades]);
+
+  const registerTrigger = useCallback(
+    (value: string, node: HTMLButtonElement | null) => {
+      if (node) {
+        triggerRefs.current.set(value, node);
+      } else {
+        triggerRefs.current.delete(value);
+      }
+    },
+    [],
+  );
+
+  const handleAccordionChange = useCallback((value: string | undefined) => {
+    setActiveAccordion(value);
+
+    if (!value) return;
+
+    requestAnimationFrame(() => {
+      triggerRefs.current.get(value)?.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    });
+  }, []);
+
+  if (isGradesLoading) {
     return (
       <div className="flex flex-col items-center justify-center py-20 gap-4">
         <div className="w-12 h-12 rounded-full border-4 border-[#FCA627] border-t-transparent animate-spin" />
         <p className="text-gray-500 font-medium">Loading tuition rates...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-red-500 font-medium">
-          Failed to load tuition rates.
-        </p>
       </div>
     );
   }
@@ -200,46 +419,20 @@ export default function TuitionRatesByGrade() {
         type="single"
         collapsible
         value={activeAccordion}
-        onValueChange={setActiveAccordion}
+        onValueChange={handleAccordionChange}
         className="space-y-3"
       >
-        {grades.map((grade: Grade, idx: number) => {
-          const itemValue = grade.id || `grade-${idx}`;
-          const gradeRates = tuitionRatesByGradeId[grade.id] || [];
+        {grades.map((grade: GradeWithCount, idx: number) => {
+          const itemValue = grade.id || grade._id || `grade-${idx}`;
 
           return (
-            <AccordionItem
+            <GradeTuitionRatesItem
               key={itemValue}
-              value={itemValue}
-              className="rounded-2xl overflow-hidden shadow-md border border-gray-100 bg-white"
-            >
-              <AccordionPrimitive.Header className="flex">
-                <AccordionPrimitive.Trigger className="flex w-full min-w-0 items-center justify-between gap-3 px-3 sm:px-5 py-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-left [&[data-state=open]_.chevron]:rotate-180">
-                  <div className="flex min-w-0 items-center gap-2 sm:gap-3">
-                    <div className="bg-white/20 rounded-full p-1.5 shrink-0">
-                      <BookOpen className="w-4 h-4 sm:w-5 sm:h-5 text-white" />
-                    </div>
-
-                    <h2 className="text-white font-bold text-base sm:text-lg tracking-wide min-w-0 truncate">
-                      {grade.title}
-                    </h2>
-                  </div>
-
-                  <div className="flex items-center gap-3 shrink-0">
-                    <span className="hidden sm:inline-flex items-center bg-white/20 text-white text-xs font-semibold px-3 py-1 rounded-full whitespace-nowrap">
-                      {gradeRates.length} item
-                      {gradeRates.length === 1 ? "" : "s"}
-                    </span>
-
-                    <ChevronDown className="chevron w-5 h-5 text-white shrink-0 transition-transform duration-300" />
-                  </div>
-                </AccordionPrimitive.Trigger>
-              </AccordionPrimitive.Header>
-
-              <AccordionContent>
-                <TuitionRateTable items={gradeRates} />
-              </AccordionContent>
-            </AccordionItem>
+              grade={grade}
+              itemValue={itemValue}
+              isActive={activeAccordion === itemValue}
+              registerTrigger={(node) => registerTrigger(itemValue, node)}
+            />
           );
         })}
       </Accordion>

--- a/src/store/api/splits/tuition-rates/index.ts
+++ b/src/store/api/splits/tuition-rates/index.ts
@@ -53,7 +53,7 @@ export const TuitionRatesApi = baseApi.injectEndpoints({
     // ✅ Fetch tuition rates by grade ID
     fetchTuitionRatesByGrade: build.query<
       PaginatedResponse<TuitionRateItem>,
-      { gradeId: string; limit?: number; page?: number }
+      { gradeId: string; limit?: number; page?: number; search?: string }
     >({
       query: ({ gradeId, ...rest }) => ({
         url: `${Endpoints.TuitionRatesByGrade}/${gradeId}`,

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -128,6 +128,8 @@ export type FetchTuitionRatesRequest = {
   tutorType?: string;
   subject?: string;
   grade?: string;
+  search?: string;
+  sortBy?: string;
   maximumRate?: string;
   minimumRate?: string;
   page?: number;

--- a/src/types/response-types.ts
+++ b/src/types/response-types.ts
@@ -17,6 +17,9 @@ export type PaginatedResponse<T> = {
   count: number;
   next: string | null;
   previous: string | null;
+  page?: number;
+  limit?: number;
+  totalPages?: number;
   results: T[];
   tags: T[];
   totalResults: number;


### PR DESCRIPTION
## Summary

- Updated the tuition rates page to load grade counts first using the grades-with-counts endpoint.
- Added lazy loading for tuition-rate rows by grade when an accordion item is opened.
- Added per-grade infinite scroll using the `/v1/tuitionRates/by-grade/:gradeId` paginated API.
- Kept the first grade open by default while ensuring only one grade accordion stays open at a time.
- Fixed duplicate row accumulation during pagination.
- Improved accordion scroll behavior to reduce page jump when switching grades.
- Updated the tuition-rate table layout to prevent column/content overlap on smaller screens.

## Technical Notes

- Replaced global tuition-rate fetching with per-grade fetching.
- Added pagination metadata support to shared paginated response types.
- Added `search` and `sortBy` support to tuition-rate request types.
- Extended the grade-specific tuition-rates API query type to support paginated search params.
- Used stable deduplication keys when merging paginated tuition-rate rows.
- Added explicit minimum table column widths and horizontal overflow handling.
