### PR TITLE
fix(client-portal): resolve mobile UI bugs — focus border, form spacing, spinner controls, blog FAB and tutor dialog improvements

### DIFF
--- a/src/app/blogs/components/ViewBlogs.tsx
+++ b/src/app/blogs/components/ViewBlogs.tsx
@@ -29,6 +29,7 @@ export default function BlogsDashboard() {
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [pageSize, setPageSize] = useState(6);
   const [visibleCount, setVisibleCount] = useState(6);
+  const [isScrolled, setIsScrolled] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const { user } = useAuthContext();
@@ -42,6 +43,12 @@ export default function BlogsDashboard() {
     update();
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
+  }, []);
+
+  useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 50);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   const loadBlogs = useCallback(
@@ -374,7 +381,7 @@ export default function BlogsDashboard() {
         <Link
           href="/blogs/components/create-blog"
           aria-label="Add new blog"
-          className="lg:hidden fixed bottom-6 right-6 z-50 w-14 h-14 flex items-center justify-center rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white shadow-lg shadow-blue-500/40 transition-all duration-200"
+          className={`lg:hidden fixed ${isScrolled ? "bottom-20" : "bottom-6"} right-4 z-50 flex items-center gap-2 px-4 h-12 rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-sm font-semibold shadow-lg shadow-blue-500/40 transition-all duration-300`}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -384,11 +391,12 @@ export default function BlogsDashboard() {
             strokeWidth="2.5"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="w-6 h-6"
+            className="w-5 h-5 flex-shrink-0"
           >
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
+          Add Blog
         </Link>
       )}
     </>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,17 @@
 @import "slick-carousel/slick/slick.css";
 @import "slick-carousel/slick/slick-theme.css";
 
+/* Suppress native blue tap highlight on mobile */
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Remove focus outline on mouse/touch — preserved for keyboard navigation */
+:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
 html {
   --site-shell-offset: 72px;
   --scroll-behavior: smooth !important;

--- a/src/app/register-tutor/components/AcademicExperience.tsx
+++ b/src/app/register-tutor/components/AcademicExperience.tsx
@@ -257,7 +257,7 @@ const AcademicExperience = () => {
             min={0}
             max={50}
             step={1}
-            className={`${inputClass} ${errors.yearsExperience ? "border-red-500" : "border-gray-300"}`}
+            className={`${inputClass} !block ${errors.yearsExperience ? "border-red-500" : "border-gray-300"}`}
             {...register("yearsExperience", {
               valueAsNumber: true,
               onChange: (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/app/register-tutor/components/TutorTabs.tsx
+++ b/src/app/register-tutor/components/TutorTabs.tsx
@@ -390,11 +390,30 @@ export function TutorTabs() {
             <DialogTitle className="text-center text-xl font-semibold">
               Registration Submitted!
             </DialogTitle>
-            <DialogDescription className="text-center text-base">
-              Your tutor profile has been submitted successfully. Our team will
-              review it and get back to you shortly.
+            <DialogDescription className="text-center text-sm text-gray-500">
+              Your tutor profile has been submitted successfully and is
+              currently under review.
             </DialogDescription>
           </DialogHeader>
+          <div className="flex items-start gap-3 bg-blue-50 border border-blue-100 rounded-lg px-4 py-3 mt-1">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+            <p className="text-sm text-blue-700 leading-snug">
+              We&apos;ll notify you via email once your account is approved.
+            </p>
+          </div>
           <DialogFooter className="justify-center mt-2">
             <Button className="w-full sm:w-auto" onClick={handleDone}>
               Done

--- a/src/app/request-for-tutors/create-request/page.tsx
+++ b/src/app/request-for-tutors/create-request/page.tsx
@@ -420,7 +420,7 @@ export default function AddRequestForTutor() {
                   Tutor Details
                 </CardTitle>
               </CardHeader>
-              <CardContent className="flex flex-col gap-3">
+              <CardContent className="flex flex-col gap-4">
                 {/* Medium */}
                 <div className={fieldWrapper}>
                   <Label className="text-sm" htmlFor="medium">
@@ -440,7 +440,9 @@ export default function AddRequestForTutor() {
                       </option>
                     ))}
                   </select>
-                  <p className={errorMsg}>{errors.medium?.message}</p>
+                  {errors.medium?.message && (
+                    <p className={errorMsg}>{errors.medium.message}</p>
+                  )}
                 </div>
 
                 {/* Grade */}
@@ -462,7 +464,9 @@ export default function AddRequestForTutor() {
                       </option>
                     ))}
                   </select>
-                  <p className={errorMsg}>{errors.grade?.message}</p>
+                  {errors.grade?.message && (
+                    <p className={errorMsg}>{errors.grade.message}</p>
+                  )}
                 </div>
 
                 {/* Number of Tutors */}
@@ -490,10 +494,10 @@ export default function AddRequestForTutor() {
                 </div>
 
                 {/* Per-tutor fields */}
-                {tutors.map((tutor, index) => (
+                {tutors.map((_tutor, index) => (
                   <div
                     key={index}
-                    className="p-4 border border-gray-200 rounded-md flex flex-col gap-3"
+                    className="p-4 border border-gray-200 rounded-md flex flex-col gap-4"
                   >
                     <h3 className="text-base font-semibold">
                       Tutor {index + 1}
@@ -521,12 +525,14 @@ export default function AddRequestForTutor() {
                           </option>
                         ))}
                       </select>
-                      <p className={errorMsg}>
-                        {errors.tutors?.[index]?.subject?.message}
-                      </p>
+                      {errors.tutors?.[index]?.subject?.message && (
+                        <p className={errorMsg}>
+                          {errors.tutors[index].subject?.message}
+                        </p>
+                      )}
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       {/* Duration */}
                       <div className={fieldWrapper}>
                         <Label
@@ -549,9 +555,11 @@ export default function AddRequestForTutor() {
                             </option>
                           ))}
                         </select>
-                        <p className={errorMsg}>
-                          {errors.tutors?.[index]?.duration?.message}
-                        </p>
+                        {errors.tutors?.[index]?.duration?.message && (
+                          <p className={errorMsg}>
+                            {errors.tutors[index].duration?.message}
+                          </p>
+                        )}
                       </div>
 
                       {/* Frequency */}
@@ -576,14 +584,16 @@ export default function AddRequestForTutor() {
                             </option>
                           ))}
                         </select>
-                        <p className={errorMsg}>
-                          {errors.tutors?.[index]?.frequency?.message}
-                        </p>
+                        {errors.tutors?.[index]?.frequency?.message && (
+                          <p className={errorMsg}>
+                            {errors.tutors[index].frequency?.message}
+                          </p>
+                        )}
                       </div>
                     </div>
 
                     {/* Preferred Tutor Type + Preferred Class Type */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div className={fieldWrapper}>
                         <Label
                           className="text-sm"
@@ -606,9 +616,12 @@ export default function AddRequestForTutor() {
                             </option>
                           ))}
                         </select>
-                        <p className={errorMsg}>
-                          {errors.tutors?.[index]?.preferredTutorType?.message}
-                        </p>
+                        {errors.tutors?.[index]?.preferredTutorType
+                          ?.message && (
+                          <p className={errorMsg}>
+                            {errors.tutors[index].preferredTutorType?.message}
+                          </p>
+                        )}
                       </div>
 
                       <div className={fieldWrapper}>
@@ -633,9 +646,12 @@ export default function AddRequestForTutor() {
                             </option>
                           ))}
                         </select>
-                        <p className={errorMsg}>
-                          {errors.tutors?.[index]?.preferredClassType?.message}
-                        </p>
+                        {errors.tutors?.[index]?.preferredClassType
+                          ?.message && (
+                          <p className={errorMsg}>
+                            {errors.tutors[index].preferredClassType?.message}
+                          </p>
+                        )}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Tickets:
- https://softvilmedia-team.atlassian.net/browse/TM-976
- https://softvilmedia-team.atlassian.net/browse/TM-985
- https://softvilmedia-team.atlassian.net/browse/TM-986
- https://softvilmedia-team.atlassian.net/browse/TM-987

Summary: Fixed multiple mobile UI bugs across the Client Portal including 
blue focus borders on buttons, excessive form spacing in the Request for 
Tutor flow, invisible spinner controls on mobile, missing Add Blog button 
in mobile view, and improved the tutor registration success dialog copy 
and design.

Changes:

Frontend:
* (TM-987) Added global CSS rules to remove blue focus border on 
  touch/click interactions while preserving keyboard accessibility 
  via :focus:not(:focus-visible) and -webkit-tap-highlight-color
* (TM-986) Replaced circle FAB with labeled pill FAB (+ Add Blog) 
  on mobile blogs page — scroll-aware positioning to avoid overlap 
  with back-to-top button
* (TM-976) Fixed Years of Experience spinner controls not visible 
  on mobile by overriding flex display to block on the number input
* (TM-985) Reduced excessive vertical spacing in Tutor Details step 
  of Request for Tutor form — aligned gap values and error paragraph 
  handling to match Contact Details step
* Improved tutor registration success dialog with updated copy and 
  a highlighted email notification banner

Backend:
* No backend changes in this PR

Files changed:
* src/app/globals.css
* src/app/blogs/components/ViewBlogs.tsx
* src/app/register-tutor/components/AcademicExperience.tsx
* src/app/request-for-tutors/create-request/page.tsx
* src/app/register-tutor/components/TutorTabs.tsx

Root Cause:
* Browser default :focus styles triggered on tap/click causing blue 
  borders on all interactive elements in mobile view
* Native number input spinner controls hidden on Android Chrome due 
  to flex display applied by shadcn Input base styles
* Step 2 of Request for Tutor form had always-rendered empty error 
  paragraphs reserving 20px blank space between every field
* Mobile blog page had no visible Add Blog entry point for admin/tutor 
  roles — desktop-only button was hidden with no mobile alternative

Result:
* Blue focus borders no longer appear on button tap across all pages
* Years of Experience spinner controls render correctly on mobile
* Tutor Details form spacing is consistent with Contact Details step
* Admin/tutor users can access Add Blog from mobile via labeled FAB
* Tutor registration success dialog clearly communicates next steps 
  with email notification highlighted

Checklist:
* Self-reviewed code
* Verified focus border removed on mobile tap across multiple pages
* Verified spinner controls visible on mobile for Years of Experience
* Verified Tutor Details spacing matches Contact Details step
* Verified Add Blog FAB visible and repositions correctly on scroll
* Verified tutor registration success dialog copy and design