### PR TITLE
fix:  Added backend-driven pagination to the past exam papers page

### DIFF
--- a/src/app/past-exam-papers/components/form-test-papper-search/index.tsx
+++ b/src/app/past-exam-papers/components/form-test-papper-search/index.tsx
@@ -41,7 +41,7 @@ const FormTestPaperSearch: FC<Props> = ({
       <form onSubmit={testPaperSearchForm.handleSubmit(onSubmit)}>
         <div className="flex items-center justify-between mb-4">
           <p className="text-sm text-gray-500">
-            Search and narrow papers by grade, subject, or medium.
+            Search by year and narrow papers by grade, subject, or medium.
           </p>
           {hasActiveFilters && (
             <button
@@ -57,7 +57,7 @@ const FormTestPaperSearch: FC<Props> = ({
 
         <div className="flex flex-col gap-1 mb-6">
           <label className="text-sm font-medium text-gray-700">
-            Search Papers
+            Search by Year
           </label>
           <div className="relative">
             <Search
@@ -67,7 +67,8 @@ const FormTestPaperSearch: FC<Props> = ({
             <input
               {...testPaperSearchForm.register("search")}
               type="text"
-              placeholder="Search by paper title, subject, or year"
+              inputMode="numeric"
+              placeholder="Search papers by the year"
               autoComplete="off"
               className="block w-full rounded-md border border-linegrey px-3 py-2 pl-10 pr-9 text-gray-900 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm sm:leading-6"
             />

--- a/src/app/past-exam-papers/components/test-papper-list/index.tsx
+++ b/src/app/past-exam-papers/components/test-papper-list/index.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, { Dispatch, FC, SetStateAction } from "react";
 import Skeleton from "react-loading-skeleton";
 import Pagination from "@/components/shared/pagination";
 import { Paper } from "@/types/response-types";
@@ -10,29 +10,20 @@ import Empty from "../../../../../public/images/shared/empty.png";
 type Props = {
   availablePapers: Paper[];
   isPapersLoading: boolean;
+  currentPage: number;
+  totalPages: number;
+  totalResults: number;
+  onPageChange: Dispatch<SetStateAction<number>>;
 };
 
-const PAPERS_PER_PAGE = 12;
-
-const TestPaperList: FC<Props> = ({ availablePapers, isPapersLoading }) => {
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = Math.ceil(availablePapers.length / PAPERS_PER_PAGE);
-
-  const visiblePapers = useMemo(() => {
-    const startIndex = (currentPage - 1) * PAPERS_PER_PAGE;
-    return availablePapers.slice(startIndex, startIndex + PAPERS_PER_PAGE);
-  }, [availablePapers, currentPage]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [availablePapers]);
-
-  useEffect(() => {
-    if (totalPages > 0 && currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
-
+const TestPaperList: FC<Props> = ({
+  availablePapers,
+  isPapersLoading,
+  currentPage,
+  totalPages,
+  totalResults,
+  onPageChange,
+}) => {
   return (
     <div className="max-w-7xl mx-auto p-6 bg-white rounded-3xl mt-8">
       {isPapersLoading ? (
@@ -56,8 +47,14 @@ const TestPaperList: FC<Props> = ({ availablePapers, isPapersLoading }) => {
         </div>
       ) : availablePapers?.length > 0 ? (
         <>
+          <div className="mb-5 flex items-center justify-between gap-3">
+            <p className="text-sm font-medium text-gray-500">
+              Showing {availablePapers.length} of {totalResults} papers
+            </p>
+          </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {visiblePapers.map((paper) => (
+            {availablePapers.map((paper) => (
               <div
                 key={paper.id}
                 className="flex flex-col rounded-2xl border border-gray-100 bg-white p-5 shadow-sm hover:shadow-md transition-shadow duration-200"
@@ -124,7 +121,7 @@ const TestPaperList: FC<Props> = ({ availablePapers, isPapersLoading }) => {
           <Pagination
             currentPage={currentPage}
             totalPages={totalPages}
-            onPageChange={setCurrentPage}
+            onPageChange={onPageChange}
             className="mt-6"
           />
         </>

--- a/src/app/past-exam-papers/hooks/useLogic.tsx
+++ b/src/app/past-exam-papers/hooks/useLogic.tsx
@@ -2,160 +2,35 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, UseFormReturn } from "react-hook-form";
 import { Option } from "@/types/shared-types";
 import { useFetchGradesQuery } from "@/store/api/splits/grades";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getErrorInApiResult } from "@/utils/api";
-import toast from "react-hot-toast";
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Paper } from "@/types/response-types";
-import { useLazyFetchPapersQuery } from "@/store/api/splits/papers";
+import { useFetchPapersQuery } from "@/store/api/splits/papers";
 import {
   initialFormValues,
   PaperSearchSchema,
   paperSearchSchema,
 } from "../components/form-test-papper-search/schema";
 
-const normalizeFilterValue = (value: string) => value.trim().toLowerCase();
-
-const extractRawStringValues = (value: unknown): string[] => {
-  if (typeof value === "string" || typeof value === "number") {
-    const trimmedValue = String(value).trim();
-
-    return trimmedValue ? [trimmedValue] : [];
-  }
-
-  if (Array.isArray(value)) {
-    return value.flatMap(extractRawStringValues);
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-
-    return ["title", "name", "label", "text", "value", "id", "_id"].flatMap(
-      (key) => extractRawStringValues(record[key]),
-    );
-  }
-
-  return [];
-};
-
-const extractStringValues = (value: unknown): string[] => {
-  return extractRawStringValues(value).map(normalizeFilterValue);
-};
-
-const getFirstRawStringValue = (...values: unknown[]) =>
-  values.flatMap(extractRawStringValues)[0] || "";
-
-const extractMediumOptions = (value: unknown): Option[] => {
-  if (typeof value === "string" || typeof value === "number") {
-    const trimmedValue = String(value).trim();
-
-    return trimmedValue
-      ? [
-          {
-            label: trimmedValue,
-            value: trimmedValue,
-          },
-        ]
-      : [];
-  }
-
-  if (Array.isArray(value)) {
-    return value.flatMap(extractMediumOptions);
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const label = getFirstRawStringValue(
-      record.title,
-      record.name,
-      record.label,
-      record.text,
-      record.value,
-      record.id,
-      record._id,
-    );
-    const optionValue = getFirstRawStringValue(
-      record.id,
-      record._id,
-      record.value,
-      record.title,
-      record.name,
-      record.label,
-      record.text,
-    );
-
-    return label && optionValue
-      ? [
-          {
-            label,
-            value: optionValue,
-          },
-        ]
-      : ["title", "name", "label", "text", "value", "id", "_id"].flatMap(
-          (key) => extractMediumOptions(record[key]),
-        );
-  }
-
-  return [];
-};
-
-const getPaperMediumValues = (paper: Paper): string[] => {
-  const rawPaper = paper as Paper & Record<string, unknown>;
-
-  return [
-    rawPaper.medium,
-    rawPaper.language,
-    rawPaper.languages,
-    rawPaper.mediums,
-  ].flatMap(extractStringValues);
-};
-
-const getPaperGradeValues = (paper: Paper): string[] => {
-  return extractStringValues(paper.grade);
-};
-
-const getPaperSubjectValues = (paper: Paper): string[] => {
-  return extractStringValues(paper.subject);
-};
-
-const getPaperSubjectOptions = (papers: Paper[]): Option[] => {
-  const optionsMap = new Map<string, Option>();
-
-  papers.forEach((paper) => {
-    extractMediumOptions(paper.subject).forEach((option) => {
-      const optionKey = normalizeFilterValue(String(option.value));
-
-      if (optionKey && !optionsMap.has(optionKey)) {
-        optionsMap.set(optionKey, option);
-      }
-    });
-  });
-
-  return Array.from(optionsMap.values());
-};
-
-const getPaperMediumOptions = (papers: Paper[]): Option[] => {
-  const optionsMap = new Map<string, Option>();
-
-  papers.forEach((paper) => {
-    const rawPaper = paper as Paper & Record<string, unknown>;
-
-    [rawPaper.medium, rawPaper.language, rawPaper.languages, rawPaper.mediums]
-      .flatMap(extractMediumOptions)
-      .forEach((option) => {
-        const optionKey = normalizeFilterValue(String(option.value));
-
-        if (optionKey && !optionsMap.has(optionKey)) {
-          optionsMap.set(optionKey, option);
-        }
-      });
-  });
-
-  return Array.from(optionsMap.values());
-};
+const PAPERS_PER_PAGE = 12;
+const PAPER_MEDIUM_OPTIONS: Option[] = [
+  { label: "Sinhala", value: "Sinhala" },
+  { label: "English", value: "English" },
+  { label: "Tamil", value: "Tamil" },
+];
 
 type LogicReturnType = {
   forms: {
     testPaperSearchForm: UseFormReturn<PaperSearchSchema>;
+  };
+  actions: {
+    setCurrentPage: Dispatch<SetStateAction<number>>;
   };
   derivedData: {
     gradesOptions: Option[];
@@ -165,15 +40,17 @@ type LogicReturnType = {
     isSubjectsLoading: boolean;
     isPapersLoading: boolean;
     papers: Paper[];
+    currentPage: number;
+    totalPages: number;
+    totalResults: number;
     isEdexcelGradeSelected: boolean;
   };
 };
 
-const PAPER_LIMIT = 10000;
 const useLogic = (): LogicReturnType => {
-  const [papers, setPapers] = useState<Paper[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
 
-  const testPaperSearchForm = useForm({
+  const testPaperSearchForm = useForm<PaperSearchSchema>({
     resolver: zodResolver(paperSearchSchema),
     defaultValues: initialFormValues,
     mode: "onChange",
@@ -182,6 +59,8 @@ const useLogic = (): LogicReturnType => {
 
   const [selectedGrade, selectedSubject, selectedMedium, searchTerm] =
     testPaperSearchForm.watch(["grade", "subject", "medium", "search"]);
+  const selectedYear = searchTerm.trim();
+  const isFullYearSearch = /^\d{4}$/.test(selectedYear);
 
   const { data: gradesRowData, isLoading: isGradesLoading } =
     useFetchGradesQuery({
@@ -189,63 +68,71 @@ const useLogic = (): LogicReturnType => {
       page: 1,
     });
 
-  const [fetchPapers, { isLoading: isPapersLoading }] =
-    useLazyFetchPapersQuery();
+  const paperQueryParams = useMemo(
+    () => ({
+      limit: PAPERS_PER_PAGE,
+      page: currentPage,
+      year: isFullYearSearch ? selectedYear : undefined,
+      yearSearch: selectedYear && !isFullYearSearch ? selectedYear : undefined,
+      grade: selectedGrade || undefined,
+      subject: selectedSubject || undefined,
+      medium: selectedMedium || undefined,
+      sortBy: "createdAt:desc",
+    }),
+    [
+      currentPage,
+      selectedGrade,
+      selectedMedium,
+      selectedSubject,
+      isFullYearSearch,
+      selectedYear,
+    ],
+  );
 
-  const fetchTestPapers = useCallback(async () => {
-    const result = await fetchPapers({
-      limit: PAPER_LIMIT,
-      page: 1,
-    });
-    const error = getErrorInApiResult(result);
-    if (error) {
-      return toast.error(error);
-    }
-    if (result.data) {
-      setPapers(result.data.results);
-    }
-  }, [fetchPapers]);
+  const {
+    data: papersData,
+    isLoading: isPapersInitialLoading,
+    isFetching: isPapersFetching,
+  } = useFetchPapersQuery(paperQueryParams);
 
-  useEffect(() => {
-    fetchTestPapers();
-  }, [fetchTestPapers]);
-
-  const gradesOptions =
-    gradesRowData?.results.map((grade) => ({
-      label: grade.title,
-      value: grade.id.toString(),
-    })) || [];
+  const gradesOptions = useMemo(
+    () =>
+      gradesRowData?.results.map((grade) => ({
+        label: grade.title,
+        value: grade.id.toString(),
+      })) || [],
+    [gradesRowData],
+  );
 
   const subjectOptions = useMemo(() => {
     if (selectedGrade) {
       const selectedGradeData = gradesRowData?.results.find(
-        (g) => g.id.toString() === selectedGrade,
+        (grade) => grade.id.toString() === selectedGrade,
       );
-      if (selectedGradeData?.subjects?.length) {
-        return selectedGradeData.subjects.map((s) => ({
-          label: s.title,
-          value: s.id,
-        }));
-      }
+
+      return (
+        selectedGradeData?.subjects?.map((subject) => ({
+          label: subject.title,
+          value: subject.id,
+        })) || []
+      );
     }
-    return getPaperSubjectOptions(papers);
-  }, [selectedGrade, gradesRowData, papers]);
-  const mediumOptions = useMemo(() => getPaperMediumOptions(papers), [papers]);
 
-  useEffect(() => {
-    if (!selectedMedium) return;
+    const subjectsById = new Map<string, Option>();
 
-    const selectedMediumExists = mediumOptions.some(
-      (option) => String(option.value) === selectedMedium,
-    );
-
-    if (!selectedMediumExists) {
-      setValue("medium", "", {
-        shouldValidate: true,
-        shouldDirty: true,
+    gradesRowData?.results.forEach((grade) => {
+      grade.subjects?.forEach((subject) => {
+        if (!subjectsById.has(subject.id)) {
+          subjectsById.set(subject.id, {
+            label: subject.title,
+            value: subject.id,
+          });
+        }
       });
-    }
-  }, [mediumOptions, selectedMedium, setValue]);
+    });
+
+    return Array.from(subjectsById.values());
+  }, [selectedGrade, gradesRowData]);
 
   const isFirstGradeMount = useRef(true);
   useEffect(() => {
@@ -253,62 +140,41 @@ const useLogic = (): LogicReturnType => {
       isFirstGradeMount.current = false;
       return;
     }
+
     setValue("subject", "", {
       shouldValidate: false,
       shouldDirty: true,
     });
   }, [selectedGrade, setValue]);
 
-  const normalizedSearchTerm = normalizeFilterValue(searchTerm);
-  const normalizedSelectedGrade = normalizeFilterValue(selectedGrade);
-  const normalizedSelectedSubject = normalizeFilterValue(selectedSubject);
-  const normalizedSelectedMedium = normalizeFilterValue(selectedMedium);
-
-  const filteredPapers = papers.filter((paper) => {
-    const searchableContent = [
-      paper.title,
-      paper.subject?.title,
-      paper.grade?.title,
-      paper.year,
-    ]
-      .join(" ")
-      .toLowerCase();
-
-    const matchesSearch =
-      !normalizedSearchTerm || searchableContent.includes(normalizedSearchTerm);
-
-    const matchesGrade =
-      !normalizedSelectedGrade ||
-      getPaperGradeValues(paper).includes(normalizedSelectedGrade);
-    const matchesSubject =
-      !normalizedSelectedSubject ||
-      getPaperSubjectValues(paper).includes(normalizedSelectedSubject);
-    const paperMediumValues = getPaperMediumValues(paper);
-    const matchesMedium =
-      !normalizedSelectedMedium ||
-      paperMediumValues.includes(normalizedSelectedMedium);
-
-    return matchesSearch && matchesGrade && matchesSubject && matchesMedium;
-  });
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, selectedGrade, selectedSubject, selectedMedium]);
 
   const isEdexcelGradeSelected =
     !!selectedGrade &&
     gradesOptions.some(
-      (g) => g.value === selectedGrade && /edexcel/i.test(g.label),
+      (grade) => grade.value === selectedGrade && /edexcel/i.test(grade.label),
     );
 
   return {
     forms: {
       testPaperSearchForm,
     },
+    actions: {
+      setCurrentPage,
+    },
     derivedData: {
       gradesOptions,
       subjectOptions,
-      mediumOptions,
+      mediumOptions: PAPER_MEDIUM_OPTIONS,
       isGradesLoading,
-      isSubjectsLoading: isPapersLoading,
-      isPapersLoading,
-      papers: filteredPapers,
+      isSubjectsLoading: isGradesLoading,
+      isPapersLoading: isPapersInitialLoading || isPapersFetching,
+      papers: papersData?.results || [],
+      currentPage: papersData?.page || currentPage,
+      totalPages: papersData?.totalPages || 0,
+      totalResults: papersData?.totalResults || 0,
       isEdexcelGradeSelected,
     },
   };

--- a/src/app/past-exam-papers/page.tsx
+++ b/src/app/past-exam-papers/page.tsx
@@ -48,8 +48,12 @@ const TestPapers = () => {
       isSubjectsLoading,
       papers: availablePapers,
       isPapersLoading,
+      currentPage,
+      totalPages,
+      totalResults,
       isEdexcelGradeSelected,
     },
+    actions: { setCurrentPage },
     forms: { testPaperSearchForm },
   } = useLogic();
 
@@ -79,7 +83,7 @@ const TestPapers = () => {
           testPaperSearchForm={testPaperSearchForm}
           isGradesLoading={isGradesLoading}
           isSubjectsLoading={isSubjectsLoading}
-          isMediumsLoading={isPapersLoading}
+          isMediumsLoading={false}
         />
       </div>
 
@@ -89,6 +93,10 @@ const TestPapers = () => {
         <TestPaperList
           availablePapers={availablePapers}
           isPapersLoading={isPapersLoading}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalResults={totalResults}
+          onPageChange={setCurrentPage}
         />
       )}
       <WhatsAppButton />

--- a/src/store/api/splits/papers/index.ts
+++ b/src/store/api/splits/papers/index.ts
@@ -17,4 +17,4 @@ export const PaperApi = baseApi.injectEndpoints({
   overrideExisting: false,
 });
 
-export const { useLazyFetchPapersQuery } = PaperApi;
+export const { useFetchPapersQuery, useLazyFetchPapersQuery } = PaperApi;

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -113,9 +113,14 @@ export type FetchLevelRequest = {
 export type FetchPapersRequest = {
   page: number;
   limit: number;
+  title?: string;
+  year?: string;
+  yearSearch?: string;
   grade?: string;
   subject?: string;
   medium?: string;
+  sortBy?: string;
+  order?: string;
 };
 
 export type FetchGradesRequest = {


### PR DESCRIPTION
## Summary

- Added backend-driven pagination to the past exam papers page.
- Updated paper filters to use backend query params instead of client-side filtering.
- Added year search support with exact and partial year behavior.
- Kept the shared pagination component API unchanged.

## Details

- Calls `/v1/papers` with `page`, `limit`, and `sortBy`.
- Sends selected filters as direct backend params:
  - `grade`
  - `subject`
  - `medium`
- Sends year input as:
  - `year=2020` for full 4-digit years
  - `yearSearch=20` for partial year searches
- Resets pagination to page 1 when filters change.
- Displays server pagination metadata, including total result count.
- Updated search UI copy to reflect year-based searching.

<img width="1902" height="942" alt="image" src="https://github.com/user-attachments/assets/1a8b9e19-9e80-4022-aaeb-ada4724c0399" />

