### PR TITLE
fix: standardize email validation and normalize Teaching Profile text fields

### DIFF
--- a/src/app/contact-us/schema.ts
+++ b/src/app/contact-us/schema.ts
@@ -1,8 +1,6 @@
 import { removeWhitespace } from "@/utils/form-normalizers";
 import { z } from "zod";
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 export const contactUsPageSchema = z.object({
   name: z
     .string()
@@ -17,22 +15,8 @@ export const contactUsPageSchema = z.object({
   email: z
     .string()
     .trim()
-    .superRefine((value, context) => {
-      if (!value) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Email is required",
-        });
-        return;
-      }
-
-      if (!EMAIL_REGEX.test(value)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Please enter a valid email address",
-        });
-      }
-    }),
+    .min(1, "Email is required")
+    .email("Please enter a valid email address"),
 
   contactNumber: z.preprocess(
     removeWhitespace,

--- a/src/app/register-tutor/components/TutorProfile.tsx
+++ b/src/app/register-tutor/components/TutorProfile.tsx
@@ -30,6 +30,7 @@ const TutorProfile = () => {
   const {
     register,
     watch,
+    setValue,
     formState: { errors },
   } = useFormContext();
 
@@ -49,7 +50,12 @@ const TutorProfile = () => {
         <Textarea
           id="teachingSummary"
           className={`${textareaBase} ${textareaBorder(!!errors.teachingSummary)}`}
-          {...register("teachingSummary")}
+          {...register("teachingSummary", {
+            onBlur: (e) =>
+              setValue("teachingSummary", e.target.value.trim().replace(/ {2,}/g, " "), {
+                shouldValidate: true,
+              }),
+          })}
           placeholder="Personal qualities, teaching styles & methodologies"
           rows={4}
           maxLength={CHAR_LIMIT}
@@ -71,7 +77,12 @@ const TutorProfile = () => {
         <Textarea
           id="academicDetails"
           className={`${textareaBase} ${textareaBorder(!!errors.academicDetails)}`}
-          {...register("academicDetails")}
+          {...register("academicDetails", {
+            onBlur: (e) =>
+              setValue("academicDetails", e.target.value.trim().replace(/ {2,}/g, " "), {
+                shouldValidate: true,
+              }),
+          })}
           placeholder="Achievements & subjects taught (e.g. number of students, years, results)"
           rows={4}
           maxLength={CHAR_LIMIT}
@@ -93,7 +104,12 @@ const TutorProfile = () => {
         <Textarea
           id="studentResults"
           className={`${textareaBase} ${textareaBorder(!!errors.studentResults)}`}
-          {...register("studentResults")}
+          {...register("studentResults", {
+            onBlur: (e) =>
+              setValue("studentResults", e.target.value.trim().replace(/ {2,}/g, " "), {
+                shouldValidate: true,
+              }),
+          })}
           placeholder="Past student results, grade improvements, examination outcomes"
           rows={4}
           maxLength={CHAR_LIMIT}
@@ -115,7 +131,12 @@ const TutorProfile = () => {
         <Textarea
           id="sellingPoints"
           className={`${textareaBase} ${textareaBorder(!!errors.sellingPoints)}`}
-          {...register("sellingPoints")}
+          {...register("sellingPoints", {
+            onBlur: (e) =>
+              setValue("sellingPoints", e.target.value.trim().replace(/ {2,}/g, " "), {
+                shouldValidate: true,
+              }),
+          })}
           placeholder="Teaching methods, commitment level, what makes you stand out"
           rows={4}
           maxLength={CHAR_LIMIT}

--- a/src/app/register-tutor/components/TutorTabs.tsx
+++ b/src/app/register-tutor/components/TutorTabs.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/store/api/splits/tutor-request";
 import { getErrorInApiResult } from "@/utils/api";
 import { Spinner } from "@/components/ui/spinner";
-import { getEmailFormatError } from "@/utils/email-validation";
 import { isPhysicalClassType } from "@/configs/register-tutor";
 
 type TabKey =
@@ -155,16 +154,6 @@ export function TutorTabs() {
 
     if (tab === "personalInfo") {
       const email = getValues("email").toLowerCase();
-      const formatError = getEmailFormatError(email);
-      if (formatError) {
-        setError("email", {
-          type: "manual",
-          message: formatError,
-        });
-        setFocus("email");
-        return;
-      }
-
       const result = await checkTutorEmailAvailability(email, true);
 
       if (result.data && !result.data.available) {


### PR DESCRIPTION
## Summary

- **TM-988** – Standardized email validation across all forms. Contact Us schema replaced its local `EMAIL_REGEX` + `superRefine` with Zod's `.email()`, matching the pattern already used in Request for Tutor and Register as a Tutor. Removed the now-redundant manual `getEmailFormatError` call from `TutorTabs.nextStep` since the Zod schema handles it. Error message is consistent across all forms: _"Please enter a valid email address"_

- **TM-989** – Teaching Profile textarea fields (Short Introduction, Academic Summary, Student Results, Selling Points) now trim leading and trailing spaces on blur before storing the value.

- **TM-990** – Same four fields also collapse multiple consecutive spaces between words into a single space on blur.

## Files Changed

- `src/app/contact-us/schema.ts`
- `src/app/register-tutor/components/TutorTabs.tsx`
- `src/app/register-tutor/components/TutorProfile.tsx`

## Test Plan

- [ ] Contact Us — enter email with invalid format, confirm error shows _"Please enter a valid email address"_
- [ ] Register as a Tutor — enter invalid email on Step 1, confirm same error message
- [ ] Register as a Tutor — enter email, confirm next step proceeds without duplicate format check
- [ ] Teaching Profile — enter text with leading/trailing spaces, click away, confirm spaces are removed
- [ ] Teaching Profile — enter text with multiple spaces between words, click away, confirm collapsed to single space
- [ ] Teaching Profile — confirm valid submissions still pass through to the API correctly