### PR TITLE
feat(TM-998): split Certificates & Documents into Educational and Optional sections

### DIFF
--- a/src/app/register-tutor/components/TermsAndSubmit.tsx
+++ b/src/app/register-tutor/components/TermsAndSubmit.tsx
@@ -7,20 +7,99 @@ import { Button } from "@/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
 
 import MultiFileUploadDropzone from "@/components/upload/multi-file-upload-dropzone";
-import { DOCUMENT_TYPE_OPTIONS } from "@/configs/options";
-
-// ---------------------------------------------------------------------------
-// Select style helpers (reuse the same token as other steps)
-// ---------------------------------------------------------------------------
+import {
+  EDUCATIONAL_DOCUMENT_OPTIONS,
+  OPTIONAL_DOCUMENT_OPTIONS,
+} from "@/configs/options";
 
 const selectClass =
   "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+const DocumentRow = ({
+  fieldName,
+  index,
+  options,
+  control,
+  errors,
+  onRemove,
+  removable,
+}: {
+  fieldName: string;
+  index: number;
+  options: { value: string; text: string }[];
+  control: any;
+  errors: any;
+  onRemove: () => void;
+  removable: boolean;
+}) => {
+  const rowErrors = errors[index] ?? {};
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50">
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-gray-500 font-medium mb-1">
+          Document Type
+        </span>
+        <Controller
+          name={`${fieldName}.${index}.type`}
+          control={control}
+          render={({ field: f }) => (
+            <select
+              {...f}
+              className={`${selectClass} ${selectBorder(!!rowErrors.type)}`}
+            >
+              <option value="" disabled hidden>
+                Select type…
+              </option>
+              {options.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.text}
+                </option>
+              ))}
+            </select>
+          )}
+        />
+        {rowErrors.type && (
+          <p className="text-xs text-red-500">{rowErrors.type.message}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-gray-500 font-medium mb-1">
+          Upload File
+        </span>
+        <Controller
+          name={`${fieldName}.${index}.url`}
+          control={control}
+          render={({ field: f }) => (
+            <MultiFileUploadDropzone
+              initialUrls={f.value ? [f.value] : []}
+              onUploaded={(urls) => {
+                f.onChange(urls[urls.length - 1] ?? "");
+              }}
+            />
+          )}
+        />
+        {rowErrors.url && (
+          <p className="text-xs text-red-500">{rowErrors.url.message}</p>
+        )}
+      </div>
+
+      <div className="flex items-start pt-7">
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={!removable}
+          className="p-2 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          title="Remove this document"
+        >
+          <Trash2 size={18} />
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const TermsAndSubmit = () => {
   const {
@@ -28,126 +107,107 @@ const TermsAndSubmit = () => {
     formState: { errors },
   } = useFormContext();
 
-  const { fields, append, remove } = useFieldArray({
+  const {
+    fields: eduFields,
+    append: appendEdu,
+    remove: removeEdu,
+  } = useFieldArray({
     control,
     name: "certificatesAndQualifications",
+  });
+
+  const {
+    fields: optFields,
+    append: appendOpt,
+    remove: removeOpt,
+  } = useFieldArray({
+    control,
+    name: "optionalCertificates",
   });
 
   const certErrors = (errors.certificatesAndQualifications as any) ?? [];
 
   return (
     <div className="space-y-4">
-      {/* ── Document Uploads ── */}
+      {/* ── Certificates & Documents ── */}
       <div>
         <Label className="text-sm mb-3 block">
           Certificates &amp; Documents <span className="text-red-500">*</span>
         </Label>
 
-        <div className="space-y-3">
-          {fields.map((field, index) => {
-            const rowErrors = certErrors[index] ?? {};
-
-            return (
-              <div
+        {/* Educational Details — mandatory */}
+        <div className="mb-4">
+          <p className="text-xs font-semibold text-gray-700 mb-2">
+            Educational Details <span className="text-red-500">*</span>
+          </p>
+          <div className="space-y-3">
+            {eduFields.map((field, index) => (
+              <DocumentRow
                 key={field.id}
-                className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50"
-              >
-                {/* Document Type Dropdown */}
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-gray-500 font-medium mb-1">
-                    Document Type
-                  </span>
-                  <Controller
-                    name={`certificatesAndQualifications.${index}.type`}
-                    control={control}
-                    render={({ field: f }) => (
-                      <select
-                        {...f}
-                        className={`${selectClass} ${selectBorder(!!rowErrors.type)}`}
-                      >
-                        <option value="" disabled hidden>
-                          Select type…
-                        </option>
-                        {DOCUMENT_TYPE_OPTIONS.map((opt) => (
-                          <option key={opt.value} value={opt.value}>
-                            {opt.text}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  />
-                  {rowErrors.type && (
-                    <p className="text-xs text-red-500">
-                      {rowErrors.type.message}
-                    </p>
-                  )}
-                </div>
+                fieldName="certificatesAndQualifications"
+                index={index}
+                options={EDUCATIONAL_DOCUMENT_OPTIONS}
+                control={control}
+                errors={certErrors}
+                onRemove={() => removeEdu(index)}
+                removable={eduFields.length > 1}
+              />
+            ))}
+          </div>
 
-                {/* Upload Dropzone */}
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-gray-500 font-medium mb-1">
-                    Upload File
-                  </span>
-                  <Controller
-                    name={`certificatesAndQualifications.${index}.url`}
-                    control={control}
-                    render={({ field: f }) => (
-                      <MultiFileUploadDropzone
-                        initialUrls={f.value ? [f.value] : []}
-                        onUploaded={(urls) => {
-                          // Single-file per row — take the last uploaded URL
-                          f.onChange(urls[urls.length - 1] ?? "");
-                        }}
-                      />
-                    )}
-                  />
-                  {rowErrors.url && (
-                    <p className="text-xs text-red-500">
-                      {rowErrors.url.message}
-                    </p>
-                  )}
-                </div>
+          {typeof errors.certificatesAndQualifications?.message === "string" && (
+            <p className="text-xs text-red-500 mt-1">
+              {errors.certificatesAndQualifications.message}
+            </p>
+          )}
 
-                {/* Remove Row Button */}
-                <div className="flex items-start pt-7">
-                  <button
-                    type="button"
-                    onClick={() => remove(index)}
-                    disabled={fields.length === 1}
-                    className="p-2 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                    title="Remove this document"
-                  >
-                    <Trash2 size={18} />
-                  </button>
-                </div>
-              </div>
-            );
-          })}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3 flex items-center gap-1.5"
+            onClick={() => appendEdu({ type: "", url: "" })}
+          >
+            <Plus size={15} />
+            Add Document
+          </Button>
         </div>
 
-        {/* Root-level array error (e.g. "At least one document is required") */}
-        {typeof errors.certificatesAndQualifications?.message === "string" && (
-          <p className="text-xs text-red-500 mt-1">
-            {errors.certificatesAndQualifications.message}
+        {/* Optional Details */}
+        <div>
+          <p className="text-xs font-semibold text-gray-700 mb-2">
+            Optional Details
           </p>
-        )}
+          <div className="space-y-3">
+            {optFields.map((field, index) => (
+              <DocumentRow
+                key={field.id}
+                fieldName="optionalCertificates"
+                index={index}
+                options={OPTIONAL_DOCUMENT_OPTIONS}
+                control={control}
+                errors={[]}
+                onRemove={() => removeOpt(index)}
+                removable={true}
+              />
+            ))}
+          </div>
 
-        {/* Add Document Row */}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="mt-3 flex items-center gap-1.5"
-          onClick={() => append({ type: "", url: "" })}
-        >
-          <Plus size={15} />
-          Add Document
-        </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3 flex items-center gap-1.5"
+            onClick={() => appendOpt({ type: "", url: "" })}
+          >
+            <Plus size={15} />
+            Add Document
+          </Button>
+        </div>
       </div>
 
       {/* ── Agreements ── */}
       <div>
-        {/* Agree Terms */}
         <div className="flex items-start gap-3">
           <Controller
             name="agreeTerms"
@@ -176,7 +236,6 @@ const TermsAndSubmit = () => {
           {errors.agreeTerms?.message as string}
         </p>
 
-        {/* Agree Assignment Info */}
         <div className="flex items-start gap-3">
           <Controller
             name="agreeAssignmentInfo"

--- a/src/app/register-tutor/components/TutorTabs.tsx
+++ b/src/app/register-tutor/components/TutorTabs.tsx
@@ -109,6 +109,7 @@ export function TutorTabs() {
       academicDetails: "",
 
       certificatesAndQualifications: [{ type: "", url: "" }],
+      optionalCertificates: [],
       agreeTerms: false,
       agreeAssignmentInfo: false,
     },
@@ -175,10 +176,17 @@ export function TutorTabs() {
 
   const onSubmit = async (data: FindMyTutorForm) => {
     try {
-      // Strip confirmPassword — it is front-end only and must not reach the API
-      const { confirmPassword: _omit, ...payload } = data;
+      // Strip front-end-only fields before sending to API
+      const { confirmPassword: _omit, optionalCertificates, ...payload } = data;
+      const validOptional = (optionalCertificates ?? []).filter(
+        (c) => c.type && c.url,
+      );
       const normalizedPayload = {
         ...payload,
+        certificatesAndQualifications: [
+          ...payload.certificatesAndQualifications,
+          ...validOptional,
+        ],
         preferredLocations: payload.classType.some(isPhysicalClassType)
           ? payload.preferredLocations
           : payload.preferredLocations.length > 0

--- a/src/app/register-tutor/schema.ts
+++ b/src/app/register-tutor/schema.ts
@@ -255,6 +255,15 @@ export const step4Schema = z.object({
       }),
     )
     .min(1, "At least one document is required"),
+  optionalCertificates: z
+    .array(
+      z.object({
+        type: z.string(),
+        url: z.string(),
+      }),
+    )
+    .optional()
+    .default([]),
   agreeTerms: z.boolean().refine((v) => v, "You must agree to Terms"),
   agreeAssignmentInfo: z
     .boolean()

--- a/src/configs/options.ts
+++ b/src/configs/options.ts
@@ -222,6 +222,23 @@ export const DOCUMENT_TYPE_OPTIONS: SelectOption[] = [
   { value: "Other", text: "Other" },
 ];
 
+export const EDUCATIONAL_DOCUMENT_OPTIONS: SelectOption[] = [
+  { value: "Advanced Level Certificate", text: "Advanced Level Certificate" },
+  { value: "Ordinary Level Certificate", text: "Ordinary Level Certificate" },
+  { value: "Degree Certificate", text: "Degree Certificate" },
+  { value: "Diploma Certificate", text: "Diploma Certificate" },
+  { value: "Professional Certificate", text: "Professional Certificate" },
+  { value: "Teaching Certificate", text: "Teaching Certificate" },
+];
+
+export const OPTIONAL_DOCUMENT_OPTIONS: SelectOption[] = [
+  { value: "NIC", text: "NIC (National ID Card)" },
+  { value: "Passport", text: "Passport" },
+  { value: "Driving License", text: "Driving License" },
+  { value: "Police Clearance", text: "Police Clearance Report" },
+  { value: "Other", text: "Other" },
+];
+
 export const WEEK_DAY_VALUES = [
   "Monday",
   "Tuesday",


### PR DESCRIPTION
## Summary

- Splits the Certificates & Documents section in the Register as a Tutor form into two sub-sections
- Educational Details (mandatory) — tutors must upload at least one educational document to submit the form
- Optional Details (optional) — tutors can upload identity/supporting documents but it is not required
- No backend changes — both sections are merged into the existing certificatesAndQualifications array before the API call

## Files Changed

- src/configs/options.ts — added EDUCATIONAL_DOCUMENT_OPTIONS and OPTIONAL_DOCUMENT_OPTIONS
- src/app/register-tutor/schema.ts — added optionalCertificates as an optional field
- src/app/register-tutor/components/TermsAndSubmit.tsx — split UI into two document sections
- src/app/register-tutor/components/TutorTabs.tsx — merge logic added to onSubmit

## Test Plan

- [ ] Verify Educational Details section shows correct document types (A/L, O/L, Degree, Diploma, Professional, Teaching)
- [ ] Verify Optional Details section shows correct document types (NIC, Passport, Driving License, Police Clearance, Other)
- [ ] Confirm form cannot be submitted without filling at least one Educational document
- [ ] Confirm form can be submitted without filling Optional Details
- [ ] Confirm + Add Document works correctly in both sections
- [ ] Confirm delete works on additional Educational rows but not on the first row when it is the only one
- [ ] Confirm all uploaded documents (both sections) are saved correctly via the API