### PR TITLE
fix: dropdown placeholder colors, blog skeleton improvements, verification UI redesign and file upload fix

### DIFF
--- a/src/app/blogs/components/ViewBlogs.tsx
+++ b/src/app/blogs/components/ViewBlogs.tsx
@@ -8,7 +8,6 @@ import { useAuthContext } from "@/contexts";
 import Link from "next/link";
 import Image from "next/image";
 import { Blogs } from "@/types/response-types";
-import { Loader2 } from "lucide-react";
 
 const DEFAULT_AVATAR = "/images/logo/LightThemeLogoIcon.svg";
 const SERVER_LIMIT = 12;
@@ -23,14 +22,15 @@ export default function BlogsDashboard() {
   const [serverPage, setServerPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [isFiltering, setIsFiltering] = useState(false);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [isError, setIsError] = useState(false);
+  const isFirstRender = useRef(true);
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [pageSize, setPageSize] = useState(6);
   const [visibleCount, setVisibleCount] = useState(6);
   const [isScrolled, setIsScrolled] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
   const { user } = useAuthContext();
 
   const [fetchBlogs] = useLazyFetchBlogsQuery();
@@ -51,10 +51,14 @@ export default function BlogsDashboard() {
   }, []);
 
   const loadBlogs = useCallback(
-    async (pageNum: number) => {
+    async (pageNum: number, filtering = false) => {
       try {
         if (pageNum === 1) {
-          setIsInitialLoading(true);
+          if (filtering) {
+            setIsFiltering(true);
+          } else {
+            setIsInitialLoading(true);
+          }
           setIsError(false);
         } else {
           setIsFetchingMore(true);
@@ -72,6 +76,7 @@ export default function BlogsDashboard() {
         }
       } finally {
         setIsInitialLoading(false);
+        setIsFiltering(false);
         setIsFetchingMore(false);
       }
     },
@@ -82,7 +87,9 @@ export default function BlogsDashboard() {
     setServerPage(1);
     setBlogs([]);
     setHasMore(true);
-    loadBlogs(1);
+    const filtering = !isFirstRender.current;
+    isFirstRender.current = false;
+    loadBlogs(1, filtering);
   }, [activeTag, loadBlogs]);
 
   useEffect(() => {
@@ -148,18 +155,12 @@ export default function BlogsDashboard() {
 
         {/* Tag pills skeleton */}
         <div className="flex flex-wrap gap-4">
-          <div className="h-8 px-4 rounded-full bg-blue-600 flex items-center">
-            <span className="text-sm font-semibold invisible">All</span>
-          </div>
-          {["Study Tips", "G.C.E A/L", "G.C.E O/L", "Tutor", "Parents"].map(
-            (tag) => (
-              <Skeleton key={tag} className="h-8 rounded-full">
-                <span className="text-sm font-semibold px-4 invisible">
-                  {tag}
-                </span>
-              </Skeleton>
-            ),
-          )}
+          <div className="h-8 w-14 rounded-full bg-blue-600" />
+          <Skeleton className="h-8 w-24 rounded-full bg-bggrey" />
+          <Skeleton className="h-8 w-24 rounded-full bg-bggrey" />
+          <Skeleton className="h-8 w-24 rounded-full bg-bggrey" />
+          <Skeleton className="h-8 w-16 rounded-full bg-bggrey" />
+          <Skeleton className="h-8 w-20 rounded-full bg-bggrey" />
         </div>
 
         {/* Blog card skeletons */}
@@ -169,32 +170,20 @@ export default function BlogsDashboard() {
               key={i}
               className="bg-white border border-gray-100 rounded-2xl shadow-sm overflow-hidden flex flex-col"
             >
-              <div className="relative h-44 bg-gray-100 flex items-center justify-center">
-                <svg
-                  className="w-10 h-10 text-gray-300"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5M21 12V6.75A2.25 2.25 0 0018.75 4.5H5.25A2.25 2.25 0 003 6.75V12"
-                  />
-                </svg>
+              <div className="relative h-44 bg-gray-200 overflow-hidden">
+                <Skeleton className="absolute inset-0 rounded-none bg-gray-200" />
+                <Skeleton className="absolute bottom-2.5 right-2.5 h-6 w-20 rounded-md bg-gray-300" />
               </div>
-              <div className="p-4 flex flex-col gap-3">
+              <div className="p-4 flex flex-col gap-2">
                 <div className="flex items-center gap-2.5">
-                  <Skeleton className="h-7 w-7 rounded-full shrink-0" />
-                  <Skeleton className="h-3 w-24 rounded" />
+                  <Skeleton className="h-7 w-7 rounded-full shrink-0 bg-gray-200" />
+                  <div className="flex flex-col gap-1">
+                    <Skeleton className="h-3 w-24 rounded bg-gray-200" />
+                  </div>
                 </div>
                 <hr className="border-gray-100" />
-                <Skeleton className="h-4 w-full rounded" />
-                <Skeleton className="h-4 w-3/4 rounded" />
-                <hr className="border-gray-100" />
-                <Skeleton className="h-3 w-full rounded" />
-                <Skeleton className="h-3 w-5/6 rounded" />
+                <Skeleton className="h-4 w-full rounded bg-gray-200" />
+                <Skeleton className="h-4 w-3/4 rounded bg-gray-200" />
               </div>
             </div>
           ))}
@@ -268,6 +257,32 @@ export default function BlogsDashboard() {
           </div>
 
           {/* Blog grid */}
+          {isFiltering ? (
+            <div className="grid gap-7 md:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: pageSize }).map((_, i) => (
+                <div
+                  key={i}
+                  className="bg-white border border-gray-100 rounded-2xl shadow-sm overflow-hidden flex flex-col"
+                >
+                  <div className="relative h-44 bg-bggrey overflow-hidden">
+                    <Skeleton className="absolute inset-0 rounded-none bg-bggrey" />
+                    <Skeleton className="absolute bottom-2.5 right-2.5 h-6 w-20 rounded-md bg-linegrey" />
+                  </div>
+                  <div className="p-4 flex flex-col gap-2">
+                    <div className="flex items-center gap-2.5">
+                      <Skeleton className="h-7 w-7 rounded-full shrink-0 bg-bggrey" />
+                      <div className="flex flex-col gap-1">
+                        <Skeleton className="h-3 w-24 rounded bg-bggrey" />
+                      </div>
+                    </div>
+                    <hr className="border-bggrey" />
+                    <Skeleton className="h-4 w-full rounded bg-bggrey" />
+                    <Skeleton className="h-4 w-3/4 rounded bg-bggrey" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
           <div className="grid gap-7 md:grid-cols-2 lg:grid-cols-3">
             {visibleBlogs.map((blog, index) => {
               const imageSrc = blog.image;
@@ -362,14 +377,36 @@ export default function BlogsDashboard() {
               </p>
             )}
           </div>
+          )}
 
           {/* Infinite scroll sentinel */}
           {hasMoreToShow && <div ref={sentinelRef} className="h-4" />}
 
-          {/* Spinner while fetching next server page */}
+          {/* Skeleton cards while fetching next server page */}
           {isFetchingMore && (
-            <div className="flex justify-center py-4">
-              <Loader2 className="w-6 h-6 text-blue-500 animate-spin" />
+            <div className="grid gap-7 md:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="bg-white border border-gray-100 rounded-2xl shadow-sm overflow-hidden flex flex-col"
+                >
+                  <div className="relative h-44 bg-bggrey overflow-hidden">
+                    <Skeleton className="absolute inset-0 rounded-none bg-bggrey" />
+                    <Skeleton className="absolute bottom-2.5 right-2.5 h-6 w-20 rounded-md bg-linegrey" />
+                  </div>
+                  <div className="p-4 flex flex-col gap-2">
+                    <div className="flex items-center gap-2.5">
+                      <Skeleton className="h-7 w-7 rounded-full shrink-0 bg-bggrey" />
+                      <div className="flex flex-col gap-1">
+                        <Skeleton className="h-3 w-24 rounded bg-bggrey" />
+                      </div>
+                    </div>
+                    <hr className="border-bggrey" />
+                    <Skeleton className="h-4 w-full rounded bg-bggrey" />
+                    <Skeleton className="h-4 w-3/4 rounded bg-bggrey" />
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/src/app/register-tutor/components/AcademicExperience.tsx
+++ b/src/app/register-tutor/components/AcademicExperience.tsx
@@ -24,9 +24,11 @@ import { type ChangeEvent, useEffect, useMemo, useState } from "react";
 const fieldWrapper = "flex flex-col gap-1.5";
 const inputClass = "h-11 text-sm placeholder:text-gray-500 text-gray-900";
 const selectClass =
-  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
+  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
+const selectColor = (value: string) =>
+  value ? "text-gray-900" : "text-gray-500";
 type MultiSelectOnChange = NonNullable<
   Parameters<typeof MultiSelect>[0]["onChange"]
 >;
@@ -45,6 +47,7 @@ const AcademicExperience = () => {
   const { data: gradeData } = useFetchGradesQuery({ page: 1, limit: 50 });
   const selectedGrades = watch("grades");
   const selectedClassTypes = watch("classType");
+  const highestEducation = watch("highestEducation");
 
   const selectedGradeIds = useMemo<string[]>(() => {
     return Array.isArray(selectedGrades) ? selectedGrades : [];
@@ -228,13 +231,13 @@ const AcademicExperience = () => {
                 }
               },
             })}
-            className={`${selectClass} ${selectBorder(!!errors.highestEducation)}`}
+            className={`${selectClass} ${selectBorder(!!errors.highestEducation)} ${selectColor(highestEducation)}`}
           >
             <option value="" disabled hidden>
               Select highest education level
             </option>
             {REGISTER_HIGHEST_EDUCATION_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
+              <option key={option.value} value={option.value} className="text-gray-900">
                 {option.text}
               </option>
             ))}

--- a/src/app/register-tutor/components/PersonalInfo.tsx
+++ b/src/app/register-tutor/components/PersonalInfo.tsx
@@ -23,9 +23,11 @@ import {
 const fieldWrapper = "flex flex-col gap-1.5";
 const inputClass = "h-11 text-sm placeholder:text-gray-500 text-gray-900";
 const selectClass =
-  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
+  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
+const selectColor = (value: string) =>
+  value ? "text-gray-900" : "text-gray-500";
 const EMAIL_CHECK_DELAY_MS = 500;
 
 /** Hint text shown below a field while it has no error */
@@ -71,6 +73,9 @@ const PersonalInfo = () => {
 
   const dateOfBirth = watch("dateOfBirth");
   const email = watch("email");
+  const gender = watch("gender");
+  const nationality = watch("nationality");
+  const race = watch("race");
 
   /** Latest selectable date = today minus 18 years (tutor must be ≥ 18) */
   const maxDate = (() => {
@@ -374,13 +379,13 @@ const PersonalInfo = () => {
           id="gender"
           {...register("gender")}
           autoComplete="sex"
-          className={`${selectClass} ${selectBorder(!!errors.gender)}`}
+          className={`${selectClass} ${selectBorder(!!errors.gender)} ${selectColor(gender)}`}
         >
           <option value="" disabled hidden>
             Select your gender
           </option>
           {GENDER_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
+            <option key={option.value} value={option.value} className="text-gray-900">
               {option.text}
             </option>
           ))}
@@ -456,13 +461,13 @@ const PersonalInfo = () => {
           id="nationality"
           {...register("nationality")}
           autoComplete="country-name"
-          className={`${selectClass} ${selectBorder(!!errors.nationality)}`}
+          className={`${selectClass} ${selectBorder(!!errors.nationality)} ${selectColor(nationality)}`}
         >
           <option value="" disabled hidden>
             Select your nationality
           </option>
           {NATIONALITY_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
+            <option key={option.value} value={option.value} className="text-gray-900">
               {option.text}
             </option>
           ))}
@@ -480,13 +485,13 @@ const PersonalInfo = () => {
         <select
           id="race"
           {...register("race")}
-          className={`${selectClass} ${selectBorder(!!errors.race)}`}
+          className={`${selectClass} ${selectBorder(!!errors.race)} ${selectColor(race)}`}
         >
           <option value="" disabled hidden>
             Select your ethnicity
           </option>
           {RACE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
+            <option key={option.value} value={option.value} className="text-gray-900">
               {option.text}
             </option>
           ))}

--- a/src/app/register-tutor/components/TermsAndSubmit.tsx
+++ b/src/app/register-tutor/components/TermsAndSubmit.tsx
@@ -13,9 +13,11 @@ import {
 } from "@/configs/options";
 
 const selectClass =
-  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900";
+  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
+const selectColor = (value: string) =>
+  value ? "text-gray-900" : "text-gray-500";
 
 const DocumentRow = ({
   fieldName,
@@ -47,13 +49,13 @@ const DocumentRow = ({
           render={({ field: f }) => (
             <select
               {...f}
-              className={`${selectClass} ${selectBorder(!!rowErrors.type)}`}
+              className={`${selectClass} ${selectBorder(!!rowErrors.type)} ${selectColor(f.value)}`}
             >
               <option value="" disabled hidden>
                 Select type…
               </option>
               {options.map((opt) => (
-                <option key={opt.value} value={opt.value}>
+                <option key={opt.value} value={opt.value} className="text-gray-900">
                   {opt.text}
                 </option>
               ))}
@@ -65,7 +67,7 @@ const DocumentRow = ({
         )}
       </div>
 
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-1 min-w-0 overflow-hidden">
         <span className="text-xs text-gray-500 font-medium mb-1">
           Upload File
         </span>
@@ -128,144 +130,166 @@ const TermsAndSubmit = () => {
   const certErrors = (errors.certificatesAndQualifications as any) ?? [];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {/* ── Certificates & Documents ── */}
-      <div>
-        <Label className="text-sm mb-3 block">
-          Certificates &amp; Documents <span className="text-red-500">*</span>
-        </Label>
-
-        {/* Educational Details — mandatory */}
-        <div className="mb-4">
-          <p className="text-xs font-semibold text-gray-700 mb-2">
-            Educational Details <span className="text-red-500">*</span>
-          </p>
-          <div className="space-y-3">
-            {eduFields.map((field, index) => (
-              <DocumentRow
-                key={field.id}
-                fieldName="certificatesAndQualifications"
-                index={index}
-                options={EDUCATIONAL_DOCUMENT_OPTIONS}
-                control={control}
-                errors={certErrors}
-                onRemove={() => removeEdu(index)}
-                removable={eduFields.length > 1}
-              />
-            ))}
-          </div>
-
-          {typeof errors.certificatesAndQualifications?.message === "string" && (
-            <p className="text-xs text-red-500 mt-1">
-              {errors.certificatesAndQualifications.message}
-            </p>
-          )}
-
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="mt-3 flex items-center gap-1.5"
-            onClick={() => appendEdu({ type: "", url: "" })}
-          >
-            <Plus size={15} />
-            Add Document
-          </Button>
+      <div className="rounded-xl border border-bggrey overflow-hidden">
+        <div className="px-5 py-3 border-b border-bggrey bg-lightwhite flex items-center gap-2">
+          <svg className="w-4 h-4 text-primary-600 shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <h3 className="text-sm font-semibold text-black">
+            Certificates &amp; Documents <span className="text-red-500">*</span>
+          </h3>
         </div>
 
-        {/* Optional Details */}
-        <div>
-          <p className="text-xs font-semibold text-gray-700 mb-2">
-            Optional Details
-          </p>
-          <div className="space-y-3">
-            {optFields.map((field, index) => (
-              <DocumentRow
-                key={field.id}
-                fieldName="optionalCertificates"
-                index={index}
-                options={OPTIONAL_DOCUMENT_OPTIONS}
-                control={control}
-                errors={[]}
-                onRemove={() => removeOpt(index)}
-                removable={true}
-              />
-            ))}
+        <div className="p-5 space-y-5">
+          {/* Educational Details — mandatory */}
+          <div>
+            <p className="text-xs font-semibold text-darkgrey mb-2">
+              Educational Details <span className="text-red-500">*</span>
+            </p>
+            <div className="space-y-3">
+              {eduFields.map((field, index) => (
+                <DocumentRow
+                  key={field.id}
+                  fieldName="certificatesAndQualifications"
+                  index={index}
+                  options={EDUCATIONAL_DOCUMENT_OPTIONS}
+                  control={control}
+                  errors={certErrors}
+                  onRemove={() => removeEdu(index)}
+                  removable={eduFields.length > 1}
+                />
+              ))}
+            </div>
+
+            {typeof errors.certificatesAndQualifications?.message === "string" && (
+              <p className="text-xs text-red-500 mt-1">
+                {errors.certificatesAndQualifications.message}
+              </p>
+            )}
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3 flex items-center gap-1.5"
+              onClick={() => appendEdu({ type: "", url: "" })}
+            >
+              <Plus size={15} />
+              Add Document
+            </Button>
           </div>
 
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="mt-3 flex items-center gap-1.5"
-            onClick={() => appendOpt({ type: "", url: "" })}
-          >
-            <Plus size={15} />
-            Add Document
-          </Button>
+          <hr className="border-bggrey" />
+
+          {/* Optional Details */}
+          <div>
+            <p className="text-xs font-semibold text-darkgrey mb-2">
+              Optional Details
+            </p>
+            <div className="space-y-3">
+              {optFields.map((field, index) => (
+                <DocumentRow
+                  key={field.id}
+                  fieldName="optionalCertificates"
+                  index={index}
+                  options={OPTIONAL_DOCUMENT_OPTIONS}
+                  control={control}
+                  errors={[]}
+                  onRemove={() => removeOpt(index)}
+                  removable={true}
+                />
+              ))}
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3 flex items-center gap-1.5"
+              onClick={() => appendOpt({ type: "", url: "" })}
+            >
+              <Plus size={15} />
+              Add Document
+            </Button>
+          </div>
         </div>
       </div>
 
       {/* ── Agreements ── */}
-      <div>
-        <div className="flex items-start gap-3">
-          <Controller
-            name="agreeTerms"
-            control={control}
-            render={({ field }) => (
-              <Checkbox
-                checked={field.value}
-                onCheckedChange={field.onChange}
-                id="agreeTerms"
-              />
-            )}
-          />
-          <Label htmlFor="agreeTerms" className="flex flex-col gap-1 text-sm">
-            <span>
-              I agree to the Terms and Conditions{" "}
-              <span className="text-red-500">*</span>
-            </span>
-            <span className="text-xs text-muted-foreground">
-              I agree to receiving assignment information via SMS and understand
-              that rates are subject to negotiation. Admin fees may apply for
-              successful assignments.
-            </span>
-          </Label>
+      <div className="rounded-xl border border-bggrey overflow-hidden">
+        <div className="px-5 py-3 border-b border-bggrey bg-lightwhite flex items-center gap-2">
+          <svg className="w-4 h-4 text-primary-600 shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="text-sm font-semibold text-black">Agreements</h3>
         </div>
-        <p className="text-xs leading-4 text-red-500 min-h-4 ml-7">
-          {errors.agreeTerms?.message as string}
-        </p>
 
-        <div className="flex items-start gap-3">
-          <Controller
-            name="agreeAssignmentInfo"
-            control={control}
-            render={({ field }) => (
-              <Checkbox
-                checked={field.value}
-                onCheckedChange={field.onChange}
-                id="agreeAssignmentInfo"
-              />
-            )}
-          />
-          <Label
-            htmlFor="agreeAssignmentInfo"
-            className="flex flex-col gap-1 text-sm"
-          >
-            <span>
-              I agree to receiving assignment information regarding new Tuition
-              Assignments <span className="text-red-500">*</span>
-            </span>
-            <span className="text-xs text-muted-foreground">
-              By checking this box, you agree to receive SMS and email
-              notifications about new tutoring assignments that match your
-              preferences.
-            </span>
-          </Label>
+        <div className="p-5 space-y-1">
+          <div className="flex items-start gap-3">
+            <Controller
+              name="agreeTerms"
+              control={control}
+              render={({ field }) => (
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  id="agreeTerms"
+                  className="mt-0.5"
+                />
+              )}
+            />
+            <Label htmlFor="agreeTerms" className="flex flex-col gap-1 text-sm cursor-pointer">
+              <span className="font-semibold">
+                I agree to the{" "}
+                <span className="text-primary-600">Terms and Conditions</span>
+                {" "}<span className="text-red-500">*</span>
+              </span>
+              <span className="text-xs text-muted-foreground leading-relaxed">
+                I agree to receiving assignment information via SMS and understand
+                that rates are subject to negotiation. Admin fees may apply for
+                successful assignments.
+              </span>
+            </Label>
+          </div>
+          <p className="text-xs text-red-500 min-h-4 ml-7">
+            {errors.agreeTerms?.message as string}
+          </p>
+
+
+          <div className="flex items-start gap-3 pt-1">
+            <Controller
+              name="agreeAssignmentInfo"
+              control={control}
+              render={({ field }) => (
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  id="agreeAssignmentInfo"
+                  className="mt-0.5"
+                />
+              )}
+            />
+            <Label
+              htmlFor="agreeAssignmentInfo"
+              className="flex flex-col gap-1 text-sm cursor-pointer"
+            >
+              <span className="font-semibold">
+                I agree to receiving assignment information regarding new Tuition
+                Assignments <span className="text-red-500">*</span>
+              </span>
+              <span className="text-xs text-muted-foreground leading-relaxed">
+                By checking this box, you agree to receive SMS and email
+                notifications about new tutoring assignments that match your
+                preferences.
+              </span>
+            </Label>
+          </div>
+          <p className="text-xs text-red-500 min-h-4 ml-7">
+            {errors.agreeAssignmentInfo?.message as string}
+          </p>
         </div>
-        <p className="text-xs leading-4 text-red-500 min-h-4 ml-7">
-          {errors.agreeAssignmentInfo?.message as string}
-        </p>
       </div>
     </div>
   );

--- a/src/app/request-for-tutors/create-request/page.tsx
+++ b/src/app/request-for-tutors/create-request/page.tsx
@@ -54,9 +54,11 @@ import {
 const fieldWrapper = "flex flex-col gap-2";
 const inputClass = "h-11 text-sm placeholder:text-gray-500 text-gray-900";
 const selectClass =
-  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring transition-colors duration-150 text-gray-900";
+  "h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring transition-colors duration-150";
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
+const selectColor = (value: string) =>
+  value ? "text-gray-900" : "text-gray-500";
 const errorMsg = "text-xs text-red-500 min-h-[1.25rem]";
 const primaryActionButtonClassName = "bg-blue-600 text-white hover:bg-blue-700";
 
@@ -100,6 +102,7 @@ export default function AddRequestForTutor() {
   const tutors = watch("tutors");
   const selectedGradeId = watch("grade");
   const selectedDistrict = watch("district");
+  const selectedMedium = watch("medium");
 
   const { data: gradeData } = useFetchGradesQuery({
     page: 1,
@@ -429,13 +432,13 @@ export default function AddRequestForTutor() {
                   <select
                     id="medium"
                     {...register("medium")}
-                    className={`${selectClass} ${selectBorder(!!errors.medium)}`}
+                    className={`${selectClass} ${selectBorder(!!errors.medium)} ${selectColor(selectedMedium)}`}
                   >
                     <option value="" disabled hidden>
                       Select medium of instruction
                     </option>
                     {MEDIUM_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
+                      <option key={option.value} value={option.value} className="text-gray-900">
                         {option.text}
                       </option>
                     ))}
@@ -453,13 +456,13 @@ export default function AddRequestForTutor() {
                   <select
                     id="grade"
                     {...register("grade")}
-                    className={`${selectClass} ${selectBorder(!!errors.grade)}`}
+                    className={`${selectClass} ${selectBorder(!!errors.grade)} ${selectColor(selectedGradeId)}`}
                   >
                     <option value="" disabled hidden>
                       Select student&apos;s grade
                     </option>
                     {gradeOptions.map((g) => (
-                      <option key={g.value} value={g.value}>
+                      <option key={g.value} value={g.value} className="text-gray-900">
                         {g.text}
                       </option>
                     ))}
@@ -512,7 +515,7 @@ export default function AddRequestForTutor() {
                         id={`subject-${index}`}
                         {...register(`tutors.${index}.subject`)}
                         disabled={!selectedGradeId}
-                        className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.subject)} disabled:bg-gray-100 disabled:cursor-not-allowed`}
+                        className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.subject)} ${selectColor(tutors[index]?.subject)} disabled:bg-gray-100 disabled:cursor-not-allowed`}
                       >
                         <option value="" disabled hidden>
                           {selectedGradeId
@@ -520,7 +523,7 @@ export default function AddRequestForTutor() {
                             : "Select a grade first"}
                         </option>
                         {subjectOptions.map((s) => (
-                          <option key={s.value} value={s.value}>
+                          <option key={s.value} value={s.value} className="text-gray-900">
                             {s.text}
                           </option>
                         ))}
@@ -544,13 +547,13 @@ export default function AddRequestForTutor() {
                         <select
                           id={`duration-${index}`}
                           {...register(`tutors.${index}.duration`)}
-                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.duration)}`}
+                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.duration)} ${selectColor(tutors[index]?.duration)}`}
                         >
                           <option value="" disabled hidden>
                             Select session duration
                           </option>
                           {REQUEST_TUTOR_DURATION_OPTIONS.map((option) => (
-                            <option key={option.value} value={option.value}>
+                            <option key={option.value} value={option.value} className="text-gray-900">
                               {option.text}
                             </option>
                           ))}
@@ -573,13 +576,13 @@ export default function AddRequestForTutor() {
                         <select
                           id={`frequency-${index}`}
                           {...register(`tutors.${index}.frequency`)}
-                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.frequency)}`}
+                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.frequency)} ${selectColor(tutors[index]?.frequency)}`}
                         >
                           <option value="" disabled hidden>
                             Select sessions per week
                           </option>
                           {REQUEST_TUTOR_FREQUENCY_OPTIONS.map((option) => (
-                            <option key={option.value} value={option.value}>
+                            <option key={option.value} value={option.value} className="text-gray-900">
                               {option.text}
                             </option>
                           ))}
@@ -605,13 +608,13 @@ export default function AddRequestForTutor() {
                         <select
                           id={`tutorType-${index}`}
                           {...register(`tutors.${index}.preferredTutorType`)}
-                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.preferredTutorType)}`}
+                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.preferredTutorType)} ${selectColor(tutors[index]?.preferredTutorType)}`}
                         >
                           <option value="" disabled hidden>
                             Select preferred tutor type
                           </option>
                           {TUTOR_TYPE_OPTIONS.map((o) => (
-                            <option key={o.value} value={o.value}>
+                            <option key={o.value} value={o.value} className="text-gray-900">
                               {o.text}
                             </option>
                           ))}
@@ -635,13 +638,13 @@ export default function AddRequestForTutor() {
                         <select
                           id={`classType-${index}`}
                           {...register(`tutors.${index}.preferredClassType`)}
-                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.preferredClassType)}`}
+                          className={`${selectClass} ${selectBorder(!!errors.tutors?.[index]?.preferredClassType)} ${selectColor(tutors[index]?.preferredClassType)}`}
                         >
                           <option value="" disabled hidden>
                             Select preferred class type
                           </option>
                           {CLASS_TYPE_OPTIONS.map((o) => (
-                            <option key={o.value} value={o.value}>
+                            <option key={o.value} value={o.value} className="text-gray-900">
                               {o.text}
                             </option>
                           ))}

--- a/src/components/form-controls/district-select/index.tsx
+++ b/src/components/form-controls/district-select/index.tsx
@@ -22,8 +22,9 @@ export default function DistrictSelect({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className={[
-          "h-11 w-full rounded-md border px-3 text-[16px] bg-transparent",
+          "h-11 w-full rounded-md border px-3 text-sm bg-transparent",
           "focus:outline-none focus:ring-1 focus:ring-ring transition-colors duration-150",
+          value ? "text-gray-900" : "text-gray-500",
           borderClass,
         ].join(" ")}
       >

--- a/src/components/upload/multi-file-upload-dropzone/index.tsx
+++ b/src/components/upload/multi-file-upload-dropzone/index.tsx
@@ -364,7 +364,7 @@ export default function MultiFileUploadDropzone({
 
       <div
         {...getRootProps()}
-        className="border-2 bg-white border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-4 sm:p-6 text-center cursor-pointer transition-all hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-gray-700"
+        className="w-full min-w-0 overflow-hidden border-2 bg-white border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-4 sm:p-6 text-center cursor-pointer transition-all hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-gray-700"
       >
         <input {...getInputProps()} />
         {uploading && (
@@ -388,18 +388,21 @@ export default function MultiFileUploadDropzone({
             </p>
 
             {files.length > 0 && (
-              <div className="mt-3 flex flex-col gap-2 max-h-60 overflow-y-auto">
+              <div className="mt-3 flex flex-col gap-2 max-h-60 overflow-y-auto overflow-x-hidden">
                 {files.map((fileObj, index) => (
                   <div
                     key={index}
-                    className="flex items-center justify-between border p-2 rounded bg-gray-50 dark:bg-gray-700"
+                    className="flex items-center gap-2 min-w-0 overflow-hidden border p-2 rounded bg-gray-50 dark:bg-gray-700"
                   >
-                    <p className="truncate max-w-[65%] text-left text-sm">
+                    <p
+                      className="truncate flex-1 min-w-0 text-left text-sm"
+                      title={fileObj.file ? fileObj.file.name : (fileObj.url?.split("/").pop() ?? "Certificate")}
+                    >
                       {fileObj.file
                         ? fileObj.file.name
                         : (fileObj.url?.split("/").pop() ?? "Certificate")}
                     </p>
-                    <div className="flex items-center gap-1.5">
+                    <div className="flex items-center gap-1.5 shrink-0">
                       {/* Eye / preview button */}
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

### Dropdown Placeholder Colors
Select dropdowns across multiple forms were showing the same dark text color for both the placeholder and selected value, making it unclear whether a value had been selected. Applied a `selectColor` helper that conditionally renders gray for placeholder state and dark for selected state. Added explicit `text-gray-900` to each `<option>` to prevent color inheritance from the parent select. Applied across:
- District select component
- Register as Tutor — Personal Info (gender, nationality, race)
- Register as Tutor — Academic Experience (highest education)
- Request for Tutor — all selects (medium, grade, subject, duration, frequency, tutor type, class type)

### Blog Skeleton UI Improvements
The original blog loading skeleton showed a plain gray box with an SVG image icon for the card image area and did not match the structure of the actual loaded card. Improved to:
- Replace the SVG placeholder with a full shimmer skeleton image area matching the `h-44` card image height
- Add a date badge skeleton in the bottom-right corner of the image area
- Add logo circle skeleton and author name skeleton line matching the loaded card body layout
- Replace the infinite scroll spinner with skeleton cards (same card structure) so the loading experience is consistent throughout
- On tag filter change, only the card grid area skeletons — banner and tag pills remain visible and interactive instead of the whole page re-skeletoning

### Verification & Agreement UI Redesign
The Verification & Agreement step had all sections in a flat layout with no clear visual separation between the document upload area and the agreement checkboxes. Redesigned to:
- Wrap Certificates & Documents into a distinct bordered card with a header, document icon and section label
- Wrap Agreements into a separate bordered card with a header and checkmark icon
- Add a horizontal divider between Educational Details and Optional Details within the documents card
- Style "Terms and Conditions" text in `primary-600` to indicate it is a key term
- Bold both agreement label titles for better readability
- Applied project Tailwind config color tokens (`bggrey`, `lightwhite`, `primary-600`, `darkgrey`, `black`) replacing raw Tailwind color names

### File Upload Long Filename Overflow Fix
When a file with a long name (e.g. a screenshot filename) was uploaded, the filename text would overflow and break outside the dashed dropzone border, breaking the layout. Root cause was missing overflow containment at multiple levels of the component tree. Fixed by:
- Adding `min-w-0 overflow-hidden` to the upload file grid cell in `DocumentRow` to constrain the `1fr` grid column
- Adding `w-full min-w-0 overflow-hidden` to the dropzone root element as the hard clip boundary
- Adding `overflow-x-hidden` to the file list container
- Using `flex-1 min-w-0 truncate` on the filename element to properly truncate within flex context
- Adding `title` attribute so hovering over a truncated filename shows the full name as a native browser tooltip

## Test Plan

- [x] On district select, register as tutor and request for tutor forms — confirm placeholder text is gray and turns dark after selecting a value
- [x] Confirm each `<option>` item in all affected dropdowns renders in dark text
- [x] On blog page initial load — confirm skeleton shows shimmer image area, date badge position, logo circle and two title line skeletons per card
- [x] Confirm tag pill skeletons render as proper pill shapes with correct widths
- [x] Click a tag filter while blogs are loaded — confirm only the card grid skeletons, banner and pills stay visible and interactive
- [x] Scroll to the bottom of the blog list — confirm skeleton cards appear instead of the spinner while next page fetches
- [x] On Register as Tutor step 4 — confirm Certificates & Documents and Agreements render as two separate bordered cards with headers
- [x] Confirm "Terms and Conditions" renders in blue and both agreement labels are bold
- [x] Upload a file with a very long filename — confirm it truncates with `...` inside the dropzone boundary without overflowing
- [x] Hover over a truncated filename — confirm the full filename appears as a tooltip
- [x] Confirm existing upload, preview and remove functionality is unaffected