### PR TITLE
fix(TM-1036): correct tuition rates grade category order to match production hierarchy

### DIFF
--- a/src/app/tuition-rates/components/all-tuition-rates.tsx
+++ b/src/app/tuition-rates/components/all-tuition-rates.tsx
@@ -30,6 +30,34 @@ type TuitionRatePagination = {
 
 const TUITION_RATES_PAGE_SIZE = 10;
 
+const GRADE_SORT_KEYS = [
+  "primary",
+  "scholarship",
+  "secondary",
+  "gce ordinary",
+  "physical science",
+  "biological science",
+  "commerce",
+  "art",
+  "technology",
+  "sports",
+  "communication",
+  "computing",
+  "multimedia",
+  "language",
+  "diploma",
+  "cambridge ordinary",
+  "cambridge advanced",
+  "edexcel ordinary",
+  "edexcel advanced",
+];
+
+function getGradeSortIndex(title: string): number {
+  const normalized = title.toLowerCase().replace(/\./g, "").replace(/\s+/g, " ").trim();
+  const idx = GRADE_SORT_KEYS.findIndex((key) => normalized.includes(key));
+  return idx === -1 ? GRADE_SORT_KEYS.length : idx;
+}
+
 function getTuitionRateKey(rate: TuitionRateItem) {
   return (
     rate._id ||
@@ -362,7 +390,13 @@ export default function TuitionRatesByGrade() {
 
   const { data: gradesData, isLoading: isGradesLoading } =
     useFetchGradesWithCountsQuery();
-  const grades = useMemo(() => gradesData?.grades || [], [gradesData]);
+  const grades = useMemo(
+    () =>
+      [...(gradesData?.grades || [])].sort(
+        (a, b) => getGradeSortIndex(a.title) - getGradeSortIndex(b.title),
+      ),
+    [gradesData],
+  );
 
   useEffect(() => {
     if (activeAccordion === undefined && grades.length > 0) {


### PR DESCRIPTION
## Summary

### Problem
The Tuition Rates page was displaying grade categories in alphabetical order 
returned by the API, which did not match the approved academic hierarchy used 
in the production site. This caused the list to appear unstructured and 
inconsistent with the expected grade progression.

### Fix
Applied a client-side sort on the grades array before rendering using a 
predefined GRADE_SORT_KEYS list that reflects the correct academic hierarchy:

Grade 1–4 (Primary) → Grade 5 Scholarship → Grade 6–9 (Secondary) → 
G.C.E Ordinary Level → G.C.E A/L streams (Physical Science, Biological Science, 
Commerce, Art, Technology) → Sports & Fitness → Communication → Computing → 
Multimedia → Languages → Diplomas → Cambridge Ordinary/Advanced → 
Edexcel Ordinary/Advanced

Title normalization (stripping periods, lowercasing) ensures matching works 
for both G.C.E and GCE title variations returned by the API. 
Any unrecognised grade falls to the end without breaking the layout.
No backend changes required.

## Test Plan

- [ ] Navigate to the Tuition Rates page
- [ ] Verify grade categories appear in the correct academic hierarchy order matching the production site
- [ ] Verify Grade 1–4 (Primary) appears first and Edexcel Advanced Level appears last
- [ ] Verify G.C.E Ordinary Level appears before all G.C.E Advanced Level streams
- [ ] Verify Cambridge and Edexcel levels appear after all local grades
- [ ] Verify expanding each accordion still loads tuition rates correctly
- [ ] Verify no categories are missing or duplicated