### PR TITLE
 git push --set-upstream origin fix/TM-1039-TM-1056-profile-qualifications-blog-sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Claude Code local settings
+.claude/
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/app/blogs/components/ViewBlogs.tsx
+++ b/src/app/blogs/components/ViewBlogs.tsx
@@ -64,7 +64,11 @@ export default function BlogsDashboard() {
           setIsFetchingMore(true);
         }
 
-        const result = await fetchBlogs({ limit: SERVER_LIMIT, page: pageNum });
+        const result = await fetchBlogs({
+          limit: SERVER_LIMIT,
+          page: pageNum,
+          sortBy: "createdAt:desc",
+        });
 
         if (result.data) {
           const newBlogs = result.data.results as Blogs[];

--- a/src/app/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/profile/[id]/components/form-education-information/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import InputText from "@/components/shared/input-text";
 import {
   Controller,
@@ -17,7 +19,10 @@ import {
   TUTOR_TYPE_OPTIONS,
   isPhysicalClassType,
 } from "@/configs/register-tutor";
-import { DOCUMENT_TYPE_OPTIONS } from "@/configs/options";
+import {
+  EDUCATIONAL_DOCUMENT_OPTIONS,
+  OPTIONAL_DOCUMENT_OPTIONS,
+} from "@/configs/options";
 import { Option } from "@/types/shared-types";
 import { FC, useEffect } from "react";
 import { EducationInfoSchema } from "./schema";
@@ -48,6 +53,94 @@ const fieldControlHeightClass = "h-11";
 const selectClass = `${fieldControlHeightClass} w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-gray-900`;
 const selectBorder = (hasError: boolean) =>
   hasError ? "border-red-500" : "border-gray-300";
+const selectColor = (value: string) =>
+  value ? "text-gray-900" : "text-gray-500";
+
+const DocumentRow = ({
+  fieldName,
+  index,
+  options,
+  control,
+  errors,
+  onRemove,
+  removable,
+}: {
+  fieldName: string;
+  index: number;
+  options: { value: string; text: string }[];
+  control: any;
+  errors: any;
+  onRemove: () => void;
+  removable: boolean;
+}) => {
+  const rowErrors = errors[index] ?? {};
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50">
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-gray-500 font-medium mb-1">
+          Document Type
+        </span>
+        <Controller
+          name={`${fieldName}.${index}.type`}
+          control={control}
+          render={({ field: f }) => (
+            <select
+              {...f}
+              className={`${selectClass} ${selectBorder(!!rowErrors.type)} ${selectColor(f.value)}`}
+            >
+              <option value="" disabled hidden>
+                Select type…
+              </option>
+              {options.map((opt) => (
+                <option
+                  key={opt.value}
+                  value={opt.value}
+                  className="text-gray-900"
+                >
+                  {opt.text}
+                </option>
+              ))}
+            </select>
+          )}
+        />
+        {rowErrors.type && (
+          <p className="text-xs text-red-500">{rowErrors.type.message}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1 min-w-0 overflow-hidden">
+        <span className="text-xs text-gray-500 font-medium mb-1">
+          Upload File
+        </span>
+        <Controller
+          name={`${fieldName}.${index}.url`}
+          control={control}
+          render={({ field: f }) => (
+            <MultiFileUploadDropzone
+              initialUrls={f.value ? [f.value] : []}
+              onUploaded={(urls) => f.onChange(urls[urls.length - 1] ?? "")}
+            />
+          )}
+        />
+        {rowErrors.url && (
+          <p className="text-xs text-red-500">{rowErrors.url.message}</p>
+        )}
+      </div>
+
+      <div className="flex items-start pt-7">
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={!removable}
+          className="p-2 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          title="Remove this document"
+        >
+          <Trash2 size={18} />
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const FormEducationInfo: FC<Props> = ({
   dropdownOptionData: { gradesOptions, subjectsOptions },
@@ -57,13 +150,27 @@ const FormEducationInfo: FC<Props> = ({
 }) => {
   const { isDirty, isValid } = form.formState;
 
-  const { fields, append, remove } = useFieldArray({
+  const {
+    fields: eduFields,
+    append: appendEdu,
+    remove: removeEdu,
+  } = useFieldArray({
     control: form.control,
     name: "certificatesAndQualifications",
   });
 
+  const {
+    fields: optFields,
+    append: appendOpt,
+    remove: removeOpt,
+  } = useFieldArray({
+    control: form.control,
+    name: "optionalCertificates",
+  });
+
   const certErrors =
     (form.formState.errors.certificatesAndQualifications as any) ?? [];
+
   const [
     classType,
     preferredLocations,
@@ -233,109 +340,107 @@ const FormEducationInfo: FC<Props> = ({
               />
             </div>
 
-            <div className="mt-5">
-              <label className="block text-sm font-medium leading-6 text-gray-900 mb-3">
-                Certificates <span className="text-red-500">*</span>
-              </label>
-
-              <div className="space-y-3">
-                {fields.map((field, index) => {
-                  const rowErrors = certErrors[index] ?? {};
-                  return (
-                    <div
-                      key={field.id}
-                      className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50"
-                    >
-                      {/* Document Type */}
-                      <div className="flex flex-col gap-1">
-                        <span className="text-xs text-gray-500 font-medium mb-1">
-                          Document Type
-                        </span>
-                        <Controller
-                          name={`certificatesAndQualifications.${index}.type`}
-                          control={form.control}
-                          render={({ field: f }) => (
-                            <select
-                              {...f}
-                              className={`${selectClass} ${selectBorder(!!rowErrors.type)}`}
-                            >
-                              <option value="" disabled hidden>
-                                Select type…
-                              </option>
-                              {DOCUMENT_TYPE_OPTIONS.map((opt) => (
-                                <option key={opt.value} value={opt.value}>
-                                  {opt.text}
-                                </option>
-                              ))}
-                            </select>
-                          )}
-                        />
-                        {rowErrors.type && (
-                          <p className="text-xs text-red-500">
-                            {rowErrors.type.message}
-                          </p>
-                        )}
-                      </div>
-
-                      {/* Upload Dropzone */}
-                      <div className="flex flex-col gap-1">
-                        <span className="text-xs text-gray-500 font-medium mb-1">
-                          Upload File
-                        </span>
-                        <Controller
-                          name={`certificatesAndQualifications.${index}.url`}
-                          control={form.control}
-                          render={({ field: f }) => (
-                            <MultiFileUploadDropzone
-                              initialUrls={f.value ? [f.value] : []}
-                              onUploaded={(urls) =>
-                                f.onChange(urls[urls.length - 1] ?? "")
-                              }
-                            />
-                          )}
-                        />
-                        {rowErrors.url && (
-                          <p className="text-xs text-red-500">
-                            {rowErrors.url.message}
-                          </p>
-                        )}
-                      </div>
-
-                      {/* Remove Button */}
-                      <div className="flex items-start pt-7">
-                        <button
-                          type="button"
-                          onClick={() => remove(index)}
-                          disabled={fields.length === 1}
-                          className="p-2 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                          title="Remove this document"
-                        >
-                          <Trash2 size={18} />
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
+            {/* Certificates & Documents */}
+            <div className="mt-5 rounded-xl border border-gray-200 overflow-hidden">
+              <div className="px-5 py-3 border-b border-gray-200 bg-gray-50 flex items-center gap-2">
+                <svg
+                  className="w-4 h-4 text-primary-600 shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                <h3 className="text-sm font-semibold text-gray-900">
+                  Certificates &amp; Documents{" "}
+                  <span className="text-red-500">*</span>
+                </h3>
               </div>
 
-              {typeof form.formState.errors.certificatesAndQualifications
-                ?.message === "string" && (
-                <p className="text-xs text-red-500 mt-1">
-                  {form.formState.errors.certificatesAndQualifications.message}
-                </p>
-              )}
+              <div className="p-5 space-y-5">
+                {/* Educational Details — mandatory */}
+                <div>
+                  <p className="text-xs font-semibold text-gray-600 mb-2">
+                    Educational Details <span className="text-red-500">*</span>
+                  </p>
+                  <div className="space-y-3">
+                    {eduFields.map((field, index) => (
+                      <DocumentRow
+                        key={field.id}
+                        fieldName="certificatesAndQualifications"
+                        index={index}
+                        options={EDUCATIONAL_DOCUMENT_OPTIONS}
+                        control={form.control}
+                        errors={certErrors}
+                        onRemove={() => removeEdu(index)}
+                        removable={eduFields.length > 1}
+                      />
+                    ))}
+                  </div>
 
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="mt-3 flex items-center gap-1.5"
-                onClick={() => append({ type: "", url: "" })}
-              >
-                <Plus size={15} />
-                Add Document
-              </Button>
+                  {typeof form.formState.errors.certificatesAndQualifications
+                    ?.message === "string" && (
+                    <p className="text-xs text-red-500 mt-1">
+                      {
+                        form.formState.errors.certificatesAndQualifications
+                          .message
+                      }
+                    </p>
+                  )}
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="mt-3 flex items-center gap-1.5"
+                    onClick={() => appendEdu({ type: "", url: "" })}
+                  >
+                    <Plus size={15} />
+                    Add Document
+                  </Button>
+                </div>
+
+                <hr className="border-gray-200" />
+
+                {/* Optional Details */}
+                <div>
+                  <p className="text-xs font-semibold text-gray-600 mb-2">
+                    Optional Details
+                  </p>
+                  <div className="space-y-3">
+                    {optFields.map((field, index) => (
+                      <DocumentRow
+                        key={field.id}
+                        fieldName="optionalCertificates"
+                        index={index}
+                        options={OPTIONAL_DOCUMENT_OPTIONS}
+                        control={form.control}
+                        errors={[]}
+                        onRemove={() => removeOpt(index)}
+                        removable={true}
+                      />
+                    ))}
+                  </div>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="mt-3 flex items-center gap-1.5"
+                    onClick={() => appendOpt({ type: "", url: "" })}
+                  >
+                    <Plus size={15} />
+                    Add Document
+                  </Button>
+                </div>
+              </div>
             </div>
+
             <div className="col-span-6 sm:col-full">
               <SubmitButton
                 className="peer mt-4 rounded-lg bg-primary-700 px-4 py-3 text-center text-sm font-semibold text-white hover:bg-primary-800 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400 sm:mt-5 sm:px-5 sm:text-base"

--- a/src/app/profile/[id]/components/form-education-information/schema.ts
+++ b/src/app/profile/[id]/components/form-education-information/schema.ts
@@ -32,11 +32,20 @@ export const educationInfoSchema = z
     certificatesAndQualifications: z
       .array(
         z.object({
-          type: z.string().optional().default(""),
+          type: z.string().min(1, "Document type is required"),
           url: z.string().min(1, "Please upload a file"),
         }),
       )
       .min(1, "Certificates are required"),
+    optionalCertificates: z
+      .array(
+        z.object({
+          type: z.string(),
+          url: z.string(),
+        }),
+      )
+      .optional()
+      .default([]),
   })
   .superRefine(({ classType, preferredLocations }, ctx) => {
     if (
@@ -61,6 +70,7 @@ export const initialEducationInfoFormValues = {
   grades: [] as string[],
   subjects: [] as string[],
   certificatesAndQualifications: [] as { type: string; url: string }[],
+  optionalCertificates: [] as { type: string; url: string }[],
 };
 
 export type EducationInfoSchema = z.infer<typeof educationInfoSchema>;

--- a/src/app/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/profile/[id]/hooks/useLogic.tsx
@@ -46,6 +46,10 @@ import {
   rateOptions,
   timeZoneOptions,
 } from "./util";
+import {
+  EDUCATIONAL_DOCUMENT_OPTIONS,
+  OPTIONAL_DOCUMENT_OPTIONS,
+} from "@/configs/options";
 
 type ProfileEntity = { id?: string; _id?: string };
 type ProfileLike = Partial<ProfileResponse> & Record<string, any>;
@@ -233,6 +237,34 @@ const normalizeCertificateRows = (
       };
     })
     .filter((certificate) => Boolean(certificate.url));
+
+const OPTIONAL_TYPES = new Set(
+  OPTIONAL_DOCUMENT_OPTIONS.map((o) => o.value.toLowerCase()),
+);
+const EDUCATIONAL_TYPES = new Set(
+  EDUCATIONAL_DOCUMENT_OPTIONS.map((o) => o.value.toLowerCase()),
+);
+
+const splitCertificateRows = (
+  certificates: ProfileResponse["certificatesAndQualifications"],
+) => {
+  const rows = normalizeCertificateRows(certificates);
+  const educational: { type: string; url: string }[] = [];
+  const optional: { type: string; url: string }[] = [];
+
+  rows.forEach((row) => {
+    const typeLower = row.type.toLowerCase();
+    if (OPTIONAL_TYPES.has(typeLower)) {
+      optional.push(row);
+    } else if (EDUCATIONAL_TYPES.has(typeLower) || row.type) {
+      educational.push(row);
+    } else {
+      educational.push(row);
+    }
+  });
+
+  return { educational, optional };
+};
 
 const mergeCertificateRows = (
   primary: ProfileResponse["certificatesAndQualifications"],
@@ -556,7 +588,7 @@ const useLogic = (): LogicReturnType => {
   const educationInfoForm = useForm<EducationInfoSchema>({
     resolver: zodResolver(educationInfoSchema),
     defaultValues: initialEducationInfoFormValues,
-    mode: "onChange",
+    mode: "onTouched",
   });
 
   const languageAndTimeForm = useForm<LanguageOptionsSchema>({
@@ -637,6 +669,10 @@ const useLogic = (): LogicReturnType => {
         ? profileClassType
         : normalizeArrayValue(profile.tutoringLevels);
 
+      const { educational, optional } = splitCertificateRows(
+        profile.certificatesAndQualifications,
+      );
+
       educationInfoForm.reset({
         classType,
         preferredLocations: profile.preferredLocations ?? [],
@@ -648,9 +684,10 @@ const useLogic = (): LogicReturnType => {
         tutorMediums: profile.tutorMediums ?? [],
         grades: getProfileGradeIds(profile),
         subjects: getProfileSubjectIds(profile),
-        certificatesAndQualifications: normalizeCertificateRows(
-          profile.certificatesAndQualifications,
-        ),
+        certificatesAndQualifications: educational.length
+          ? educational
+          : [{ type: "", url: "" }],
+        optionalCertificates: optional,
       });
     },
     [educationInfoForm],
@@ -898,9 +935,13 @@ const useLogic = (): LogicReturnType => {
   };
 
   const onEducationInfoFormSubmission = async (data: EducationInfoSchema) => {
-    const certificateRows = data.certificatesAndQualifications
+    const eduRows = data.certificatesAndQualifications
       .map(({ type, url }) => ({ type, url }))
-      .filter((certificate) => Boolean(certificate.url));
+      .filter((c) => Boolean(c.url));
+    const optRows = (data.optionalCertificates ?? [])
+      .map(({ type, url }) => ({ type, url }))
+      .filter((c) => Boolean(c.url));
+    const certificateRows = [...eduRows, ...optRows];
     const submittedEducationUpdates = {
       classType: data.classType,
       preferredLocations: data.preferredLocations,
@@ -910,9 +951,7 @@ const useLogic = (): LogicReturnType => {
       tutorMediums: data.tutorMediums,
       grades: data.grades,
       subjects: data.subjects,
-      certificatesAndQualifications: certificateRows
-        .map((certificate) => certificate.url)
-        .filter(Boolean),
+      certificatesAndQualifications: certificateRows,
     };
 
     const result = await handleProfileSubmit({
@@ -934,7 +973,10 @@ const useLogic = (): LogicReturnType => {
         certificatesAndQualifications: certificateRows,
       }),
     );
-    educationInfoForm.reset(data);
+    educationInfoForm.reset({
+      ...data,
+      optionalCertificates: data.optionalCertificates ?? [],
+    });
     toast.success("Qualifications updated successfully");
   };
 

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -78,7 +78,7 @@ export type UpdateProfileRequest = {
     teachingSummary?: string;
     studentResults?: string;
     sellingPoints?: string;
-    certificatesAndQualifications?: string[];
+    certificatesAndQualifications?: Array<string | { type: string; url: string }>;
     avatar?: string;
   };
 };
@@ -167,6 +167,7 @@ export type FetchBlogsRequest = {
   title?: string;
   page?: number;
   limit?: number;
+  sortBy?: string;
 };
 
 export type FetchTagsRequest = {


### PR DESCRIPTION
## Summary

### TM-1039 — Profile: Separate Educational Details and Other Details sections
- Replaced the single combined "Certificates" section in the User Profile qualifications form with two separate labelled sections matching the Register as a Tutor form structure:
  - **Educational Details** (required) — uses Educational Document options (A/L, O/L, Degree, Diploma, Professional, Teaching certificates)
  - **Optional Details** (optional) — uses Optional Document options (NIC, Passport, Driving License, Police Clearance, Other)
- Extracted a reusable `DocumentRow` component consistent with the register tutor form
- Document type is now **required** on Educational Details (validation on blur — `onTouched` mode) matching register tutor form behaviour
- Fixed: document type was lost after page refresh because only URLs were being sent to the API. Now sends `{ type, url }` objects so the type persists correctly through profile saves

### TM-1056 — Blogs: Newest blogs displayed first
- Blogs listing page now sorts by `createdAt` descending on every fetch so newly published blogs appear at the top across all pages and page reloads

### Chore
- Added `.claude/` to `.gitignore` to prevent Claude Code local settings from being accidentally committed by any team member

## Files Changed
| File | Ticket |
|------|--------|
| `.gitignore` | Chore |
| `src/types/request-types.ts` | TM-1039, TM-1056 |
| `src/app/blogs/components/ViewBlogs.tsx` | TM-1056 |
| `src/app/profile/[id]/components/form-education-information/schema.ts` | TM-1039 |
| `src/app/profile/[id]/components/form-education-information/index.tsx` | TM-1039 |
| `src/app/profile/[id]/hooks/useLogic.tsx` | TM-1039 |

## Test Plan
- [ ] Navigate to User Profile → Qualifications section — confirm two separate sections: **Educational Details** and **Optional Details**
- [ ] Try uploading a file under Educational Details without selecting a Document Type — confirm error appears on blur and Update button stays disabled
- [ ] Select a Document Type, upload a file, save — refresh the page and confirm the type still shows correctly (not blank)
- [ ] Add a document under Optional Details — confirm no type validation error is enforced
- [ ] Navigate to Blogs page — confirm newest blog appears at the top of the list
- [ ] Add a new blog post — return to listing and confirm it appears first
- [ ] Confirm `.claude/` folder is not tracked by git