### PR TITLE
fix: improve navbar logo alignment and mobile responsiveness

### DIFF
--- a/src/components/shared/navbar/header.tsx
+++ b/src/components/shared/navbar/header.tsx
@@ -218,7 +218,7 @@ const Navbar = ({ isHeroTop = false }: NavbarProps) => {
                   fill
                   priority
                   sizes="(min-width: 1024px) 250px, (min-width: 640px) 220px, 180px"
-                  className="object-contain"
+                  className="object-contain object-left"
                 />
               </Link>
             </div>

--- a/src/components/shared/navbar/header.tsx
+++ b/src/components/shared/navbar/header.tsx
@@ -209,7 +209,7 @@ const Navbar = ({ isHeroTop = false }: NavbarProps) => {
             <div className="flex flex-shrink-0 items-center">
               <Link
                 href="/"
-                className="relative block h-12 w-[180px] sm:h-14 sm:w-[220px] lg:h-16 lg:w-[250px]"
+                className="relative block h-10 w-[150px] sm:h-14 sm:w-[220px] lg:h-16 lg:w-[250px]"
                 aria-label="Tuition Lanka home"
               >
                 <Image
@@ -381,7 +381,7 @@ const Navbar = ({ isHeroTop = false }: NavbarProps) => {
             </div>
           </div>
 
-          <div className="flex items-center gap-3 lg:hidden">
+          <div className="flex items-center gap-2 lg:hidden">
             <LocaleSwitcher />
             {user?.email ? (
               <ProfileDropdown isLoading={!isUserLoaded} user={user} />


### PR DESCRIPTION
## Summary

- Fixed navbar logo alignment by adding `object-left` to prevent extra whitespace on the left side of the logo container
- Fixed mobile header layout breaking at screen sizes below 375px (e.g. 320px) by reducing base logo size and tightening mobile controls gap

## Files Changed

- `src/components/shared/navbar/header.tsx`

## Changes Detail

### Logo Alignment Fix
- Added `object-left` to logo `Image` class — `object-contain` alone was centering the SVG within its container, leaving visible whitespace on the left

### Mobile Responsiveness Fix (< 375px)
- Reduced logo size at base (mobile) breakpoint from `w-[180px]/h-12` to `w-[150px]/h-10`
- At 320px, the previous 180px logo left only ~116px for the language selector + hamburger icon with zero breathing room, causing the header to overflow
- Tightened mobile controls gap from `gap-3` to `gap-2` for additional breathing room
- `sm:` and `lg:` logo sizes remain unchanged

## Test Plan

- [ ] Verify logo is left-aligned with no extra whitespace on desktop and mobile
- [ ] Check header at 320px — language selector and hamburger icon should both be fully visible
- [ ] Check header at 375px — layout unchanged from before
- [ ] Check header at sm (640px+) and lg (1024px+) — logo sizes unchanged