### PR TITLE
fix(TM-976): fix Years of Experience increment/decrement controls not visible on mobile

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import InputText from "@/components/shared/input-text";
+import NumberStepper from "@/components/shared/number-stepper";
 import {
   Controller,
   FormProvider,
@@ -302,15 +303,12 @@ const FormEducationInfo: FC<Props> = ({
                 reserveHelperSpace
               />
 
-              <InputText
-                label="Years of Experience *"
-                placeholder="Enter total years of experience"
+              <NumberStepper
                 name="yearsExperience"
-                type="number"
                 min={0}
                 max={50}
-                step={1}
-                className={fieldControlHeightClass}
+                label="Years of Experience"
+                required
                 reserveHelperSpace
               />
 

--- a/src/app/[locale]/register-tutor/components/AcademicExperience.tsx
+++ b/src/app/[locale]/register-tutor/components/AcademicExperience.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useFormContext, Controller } from "react-hook-form";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import MultiSelect from "@/components/shared/MultiSelect";
+import NumberStepper from "@/components/shared/number-stepper";
 
 import {
   CLASS_TYPE_OPTIONS,
@@ -19,7 +19,7 @@ import {
   useFetchGradesQuery,
   useFetchSubjectsForGradesMutation,
 } from "@/store/api/splits/grades";
-import { type ChangeEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 /** Shared style tokens – keep in sync with other register-tutor components */
 const fieldWrapper = "flex flex-col gap-1.5";
@@ -256,31 +256,13 @@ const AcademicExperience = () => {
 
       {/* ROW 3 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3">
-        <div className={fieldWrapper}>
-          <Label className="text-sm" htmlFor="yearsExperience">
-            {t("yearsExperience")} <span className="text-red-500">*</span>
-          </Label>
-          <Input
-            id="yearsExperience"
-            type="number"
-            min={0}
-            max={50}
-            step={1}
-            className={`${inputClass} !block ${errors.yearsExperience ? "border-red-500" : "border-gray-300"}`}
-            {...register("yearsExperience", {
-              valueAsNumber: true,
-              onChange: (event: ChangeEvent<HTMLInputElement>) => {
-                const value = event.target.valueAsNumber;
-                if (Number.isFinite(value) && value >= 1) {
-                  clearErrors("yearsExperience");
-                }
-              },
-            })}
-          />
-          <p className="text-xs leading-4 text-red-500 min-h-4">
-            {errors.yearsExperience?.message as string}
-          </p>
-        </div>
+        <NumberStepper
+          name="yearsExperience"
+          min={0}
+          max={50}
+          label={t("yearsExperience")}
+          required
+        />
 
         <div className={fieldWrapper}>
           <Label className="text-sm" htmlFor="tutorMediums">

--- a/src/components/shared/number-stepper/index.tsx
+++ b/src/components/shared/number-stepper/index.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Controller, useFormContext } from "react-hook-form";
+
+interface NumberStepperProps {
+  name: string;
+  min?: number;
+  max?: number;
+  label?: string;
+  required?: boolean;
+  reserveHelperSpace?: boolean;
+  inputClassName?: string;
+}
+
+const NumberStepper = ({
+  name,
+  min = 0,
+  max = 999,
+  label,
+  required = false,
+  reserveHelperSpace = false,
+  inputClassName = "",
+}: NumberStepperProps) => {
+  const {
+    control,
+    clearErrors,
+    formState: { errors },
+  } = useFormContext();
+
+  const error = errors[name]?.message as string | undefined;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && (
+        <label className="text-sm font-medium text-gray-700">
+          {label}
+          {required && <span className="text-red-500"> *</span>}
+        </label>
+      )}
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => {
+          const val =
+            typeof field.value === "number" && !isNaN(field.value)
+              ? field.value
+              : min;
+
+          const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            const raw = e.target.value;
+            if (raw === "") {
+              field.onChange(min);
+              return;
+            }
+            const parsed = parseInt(raw, 10);
+            if (!isNaN(parsed)) {
+              const clamped = Math.min(max, Math.max(min, parsed));
+              field.onChange(clamped);
+              if (clamped >= 1) clearErrors(name);
+            }
+          };
+
+          return (
+            <>
+              {/* Mobile: value on left, − + buttons grouped on right */}
+              <div
+                className={`flex sm:hidden h-11 items-center overflow-hidden rounded-md border bg-white ${
+                  error ? "border-red-500" : "border-gray-300"
+                }`}
+              >
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={val}
+                  onChange={handleChange}
+                  onBlur={field.onBlur}
+                  className="h-full flex-1 border-0 bg-transparent px-3 text-sm font-medium text-gray-900 focus:outline-none focus:ring-0"
+                />
+                <div className="flex h-full items-center border-l border-gray-200">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = Math.max(min, val - 1);
+                      field.onChange(next);
+                      if (next >= 1) clearErrors(name);
+                    }}
+                    disabled={val <= min}
+                    className="flex h-full w-11 items-center justify-center border-r border-gray-200 bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = Math.min(max, val + 1);
+                      field.onChange(next);
+                      clearErrors(name);
+                    }}
+                    disabled={val >= max}
+                    className="flex h-full w-11 items-center justify-center bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+
+              {/* Desktop (sm+): plain input matching other form fields */}
+              <input
+                type="number"
+                min={min}
+                max={max}
+                step={1}
+                value={val}
+                onChange={handleChange}
+                onBlur={field.onBlur}
+                className={`hidden sm:block h-11 w-full rounded-md border px-3 text-sm text-gray-900 placeholder:text-gray-500 bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+                  error ? "border-red-500" : "border-gray-300"
+                } ${inputClassName}`}
+              />
+            </>
+          );
+        }}
+      />
+      {(error || reserveHelperSpace) && (
+        <p className="text-xs leading-4 text-red-500 min-h-4">{error ?? ""}</p>
+      )}
+    </div>
+  );
+};
+
+export default NumberStepper;


### PR DESCRIPTION
## Summary

- TM-976: In the Register as a Tutor and Tutor Profile forms, the Years of Experience field increment/decrement controls were not visible on mobile devices
- Native browser number input spinners are not rendered on Android/iOS mobile browsers regardless of CSS — this is a fundamental mobile browser limitation
- Replaced the native number input with a reusable `NumberStepper` component that shows custom − / + controls on mobile while preserving the native spinner on desktop and tablet

## Root Cause

Mobile browsers (Chrome Android, Safari iOS) do not render native `input[type="number"]` spinner controls. No CSS override can force them to appear on real mobile devices.

## Solution

Created a new reusable `NumberStepper` component (`src/components/shared/number-stepper/`) that:
- **Mobile (< sm / below 640px):** renders a typeable input with − and + buttons grouped on the right side
- **Desktop / Tablet (sm+):** renders a standard native number input with spinner — no visual change from before

## Files Changed

- `src/components/shared/number-stepper/index.tsx` — new reusable component
- `src/app/[locale]/register-tutor/components/AcademicExperience.tsx` — Register as a Tutor form updated
- `src/app/[locale]/profile/[id]/components/form-education-information/index.tsx` — Tutor Profile form updated

## Test Plan

- [ ] Open Register as a Tutor on a real mobile device — Years of Experience shows typeable input with − / + buttons on the right
- [ ] Open Register as a Tutor on desktop — Years of Experience shows native number spinner, no visual change
- [ ] Open Tutor Profile form on mobile — same stepper behaviour
- [ ] Open Tutor Profile form on desktop — same native spinner behaviour
- [ ] Verify form validation still triggers correctly (must be greater than 0) on both mobile and desktop
- [ ] Verify − button is disabled at 0, + button is disabled at 50