### PR TITLE
feat(TM-1098): shared date picker mobile fix & home page card transition improvement

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable unused-imports/no-unused-vars */
 
 import InputText from "@/components/shared/input-text";
+import InputDatePicker from "@/components/shared/input-date-picker";
 import { FormProvider, Controller } from "react-hook-form";
 import InputSelect from "@/components/shared/input-select";
 import { FC, KeyboardEvent, useEffect, useRef } from "react";
@@ -84,7 +85,6 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
     onFormSubmit(data);
   };
 
-  const dateInputRef = useRef<HTMLInputElement | null>(null);
   const maxBirthday = getAdultBirthDateLimit();
 
   const { defaultValues, isValid } = form.formState;
@@ -207,53 +207,12 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                   );
                 }}
               />
-              <Controller
+              <InputDatePicker
                 name="birthday"
-                control={form.control}
-                render={({ field, fieldState }) => (
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="birthday"
-                      className="block text-sm font-medium leading-6 text-gray-900"
-                    >
-                      Date of Birth <span className="text-red-500">*</span>
-                    </label>
-                    <div
-                      className="relative cursor-pointer"
-                      onClick={() => dateInputRef.current?.showPicker()}
-                    >
-                      <input
-                        id="birthday"
-                        type="date"
-                        {...field}
-                        value={
-                          field.value instanceof Date
-                            ? field.value.toISOString().slice(0, 10)
-                            : (field.value ?? "")
-                        }
-                        ref={(el) => {
-                          field.ref(el);
-                          dateInputRef.current = el;
-                        }}
-                        onKeyDown={(e) => e.preventDefault()}
-                        max={maxBirthday}
-                        className={`${fieldHeightClass} w-full rounded-md border px-3 pr-10 text-sm text-gray-900 bg-white focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute ${
-                          fieldState.error
-                            ? "border-red-500"
-                            : "border-gray-300"
-                        }`}
-                      />
-                      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-400">
-                        <Icon name="Calendar" size={16} />
-                      </span>
-                    </div>
-                    {fieldState.error && (
-                      <span className="text-xs text-red-500">
-                        {fieldState.error.message}
-                      </span>
-                    )}
-                  </div>
-                )}
+                label="Date of Birth"
+                required
+                maxDate={maxBirthday}
+                reserveHelperSpace
               />
               <InputText
                 label="Age *"

--- a/src/app/[locale]/register-tutor/components/PersonalInfo.tsx
+++ b/src/app/[locale]/register-tutor/components/PersonalInfo.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import Icon from "@/components/shared/icon";
+import InputDatePicker from "@/components/shared/input-date-picker";
 import {
   collapseTextSpaces,
   removeWhitespace,
@@ -70,7 +71,6 @@ const PersonalInfo = () => {
   const [checkTutorEmailAvailability, { isFetching: isCheckingEmail }] =
     useLazyGetTutorEmailAvailabilityQuery();
 
-  const dateInputRef = useRef<HTMLInputElement | null>(null);
   const latestEmailRef = useRef("");
 
   const dateOfBirth = watch("dateOfBirth");
@@ -402,39 +402,14 @@ const PersonalInfo = () => {
       </div>
 
       {/* Date of Birth */}
-      <div className={fieldWrapper}>
-        <Label className="text-sm" htmlFor="dateOfBirth">
-          {t("dateOfBirth")} <span className="text-red-500">*</span>
-        </Label>
-        <div
-          className="relative cursor-pointer"
-          onClick={() => dateInputRef.current?.showPicker()}
-        >
-          <Input
-            id="dateOfBirth"
-            type="date"
-            {...register("dateOfBirth")}
-            ref={(el) => {
-              register("dateOfBirth").ref(el);
-              dateInputRef.current = el;
-            }}
-            onKeyDown={(e) => e.preventDefault()}
-            max={maxDate}
-            autoComplete="bday"
-            className={`${inputClass} pr-10 cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute ${errors.dateOfBirth ? "border-red-500" : "border-gray-300"}`}
-          />
-          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-400">
-            <Icon name="Calendar" size={16} />
-          </span>
-        </div>
-        {errors.dateOfBirth ? (
-          <p className="text-xs leading-4 text-red-500 min-h-4">
-            {errors.dateOfBirth?.message as string}
-          </p>
-        ) : (
-          <Hint>{t("dateOfBirthHint")}</Hint>
-        )}
-      </div>
+      <InputDatePicker
+        name="dateOfBirth"
+        label={t("dateOfBirth")}
+        required
+        maxDate={maxDate}
+        helperText={t("dateOfBirthHint")}
+        reserveHelperSpace
+      />
 
       {/* Age — auto-calculated */}
       <div className={fieldWrapper}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,30 @@ body[data-scroll-locked] {
   box-shadow: none;
 }
 
+/* Mobile date picker — brand blue theme */
+.dob-mobile-picker .react-datepicker-wrapper,
+.dob-mobile-picker .react-datepicker__input-container { width: 100%; }
+.dob-mobile-picker .react-datepicker-popper { z-index: 9999; width: calc(100vw - 3rem); max-width: 340px; }
+.dob-mobile-picker .react-datepicker { font-family: inherit; border: 1px solid #e5e7eb; border-radius: 0.75rem; overflow: hidden; box-shadow: 0 8px 32px rgba(0,0,0,0.15); width: 100%; }
+.dob-mobile-picker .react-datepicker__month-container { width: 100%; }
+.dob-mobile-picker .react-datepicker__header { background-color: #235ED5; border-bottom: none; padding: 14px 0 10px; }
+.dob-mobile-picker .react-datepicker__current-month { display: none; }
+.dob-mobile-picker .react-datepicker__navigation { top: 14px; }
+.dob-mobile-picker .react-datepicker__navigation-icon::before { border-color: #ffffff; }
+.dob-mobile-picker .react-datepicker__header__dropdown { display: flex; justify-content: center; gap: 8px; padding: 0 12px 8px; }
+.dob-mobile-picker .react-datepicker__month-select,
+.dob-mobile-picker .react-datepicker__year-select { appearance: none; -webkit-appearance: none; background-color: rgba(255,255,255,0.18); color: #ffffff; border: 1px solid rgba(255,255,255,0.5); border-radius: 6px; padding: 4px 28px 4px 10px; font-size: 0.875rem; font-weight: 600; font-family: inherit; cursor: pointer; outline: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 8px center; }
+.dob-mobile-picker .react-datepicker__month-select option,
+.dob-mobile-picker .react-datepicker__year-select option { color: #111827; background-color: #ffffff; font-weight: 400; }
+.dob-mobile-picker .react-datepicker__day-name { color: rgba(255,255,255,0.85); font-weight: 600; font-size: 0.75rem; width: 2.2rem; line-height: 2.2rem; }
+.dob-mobile-picker .react-datepicker__day { width: 2.2rem; line-height: 2.2rem; border-radius: 50%; font-size: 0.85rem; color: #374151; }
+.dob-mobile-picker .react-datepicker__day:hover { background-color: #dbeafe; border-radius: 50%; }
+.dob-mobile-picker .react-datepicker__day--selected { background-color: #235ED5 !important; color: #ffffff !important; border-radius: 50%; font-weight: 600; }
+.dob-mobile-picker .react-datepicker__day--keyboard-selected { background-color: #93c5fd; color: #1e3a8a; border-radius: 50%; }
+.dob-mobile-picker .react-datepicker__day--today:not(.react-datepicker__day--selected) { font-weight: 700; color: #235ED5; background-color: #eff6ff; }
+.dob-mobile-picker .react-datepicker__day--disabled { color: #d1d5db !important; cursor: not-allowed; }
+.dob-mobile-picker .react-datepicker__triangle { display: none; }
+
 html {
   --site-shell-offset: 72px;
   --scroll-behavior: smooth !important;

--- a/src/components/home-page/about-us/index.tsx
+++ b/src/components/home-page/about-us/index.tsx
@@ -45,9 +45,9 @@ const AboutUs = () => {
           {Aboutdata.map((item, i) => (
             <div
               key={i}
-              className={`hover:bg-navyblue bg-white rounded-3xl pt-8 pl-8 pb-8 pr-6 shadow-md group animate-on-scroll transition-all duration-300 hover:shadow-xl ${staggerClasses[i]}`}
+              className={`hover:bg-navyblue bg-white rounded-3xl pt-8 pl-8 pb-8 pr-6 shadow-md group animate-on-scroll transition-all duration-700 ease-in-out hover:shadow-xl ${staggerClasses[i]}`}
             >
-              <h4 className="text-xl font-semibold leading-[1.3] text-black mb-3 group-hover:text-white transition-colors duration-300">
+              <h4 className="text-xl font-semibold leading-[1.3] text-black mb-3 group-hover:text-white transition-colors duration-700 ease-in-out">
                 {item.heading}
               </h4>
               <Image
@@ -57,7 +57,7 @@ const AboutUs = () => {
                 height={72}
                 className="mb-4"
               />
-              <p className="text-base font-normal text-black group-hover:text-offwhite leading-relaxed transition-colors duration-300">
+              <p className="text-base font-normal text-black group-hover:text-offwhite leading-relaxed transition-colors duration-700 ease-in-out">
                 {item.paragraph}
               </p>
             </div>

--- a/src/components/shared/input-date-picker/index.tsx
+++ b/src/components/shared/input-date-picker/index.tsx
@@ -1,64 +1,132 @@
+"use client";
+
+import { useRef } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { getNestedError } from "@/utils/form";
+import Icon from "@/components/shared/icon";
 
-interface DatePickerProps {
-  label?: string;
-  helperText?: string;
+interface InputDatePickerProps {
   name: string;
-  className?: string;
-  dateFormat?: string;
-  placeholderText?: string;
-  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
+  label?: string;
+  required?: boolean;
+  maxDate?: string;
+  helperText?: string;
+  reserveHelperSpace?: boolean;
+  inputClassName?: string;
 }
 
-const InputDatePicker: React.FC<DatePickerProps> = ({
-  label,
-  helperText,
-  name,
-  className = "",
-  dateFormat = "MM/dd/yyyy",
-  placeholderText = "Select a date",
-  ...props
-}) => {
-  const { control, formState } = useFormContext();
+const toDateString = (date: Date): string =>
+  [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
 
-  const error = getNestedError(formState.errors, name);
+const InputDatePicker: React.FC<InputDatePickerProps> = ({
+  name,
+  label,
+  required = false,
+  maxDate,
+  helperText,
+  reserveHelperSpace = false,
+  inputClassName = "",
+}) => {
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext();
+
+  const dateInputRef = useRef<HTMLInputElement | null>(null);
+  const error = errors[name]?.message as string | undefined;
+  const baseInputClass = `h-11 w-full rounded-md border px-3 pr-10 text-sm text-gray-900 bg-transparent focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer caret-transparent ${
+    error ? "border-red-500" : "border-gray-300"
+  } ${inputClassName}`;
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-1.5">
       {label && (
-        <label className="text-sm font-medium text-gray-700">{label}</label>
+        <label className="text-sm font-medium text-gray-700">
+          {label}
+          {required && <span className="text-red-500"> *</span>}
+        </label>
       )}
 
-      <Controller
-        name={name}
-        control={control}
-        render={({ field }) => (
-          <>
-            <DatePicker
-              selected={field.value}
-              onChange={field.onChange}
-              className={`relative block w-full appearance-none rounded-md border px-3 py-[0.625rem] text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm  ${
-                error ? "border-red-500" : "border-gray-300"
-              } ${className}`}
-              dateFormat={dateFormat}
-              placeholderText={placeholderText}
-              {...props}
-            />
-            {(error || helperText) && (
-              <span
-                className={`text-xs ${
-                  error ? "text-red-500" : "text-gray-500"
-                }`}
-              >
-                {error || helperText}
+      {/* Desktop (sm+): native date input */}
+      <div
+        className="relative hidden sm:block cursor-pointer"
+        onClick={() => dateInputRef.current?.showPicker()}
+      >
+        <input
+          type="date"
+          {...register(name)}
+          ref={(el) => {
+            register(name).ref(el);
+            dateInputRef.current = el;
+          }}
+          onKeyDown={(e) => e.preventDefault()}
+          max={maxDate}
+          autoComplete="bday"
+          className={`${baseInputClass} pointer-events-none [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute`}
+        />
+        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-400">
+          <Icon name="Calendar" size={16} />
+        </span>
+      </div>
+
+      {/* Mobile (< sm): react-datepicker with brand colours */}
+      <div className="relative sm:hidden dob-mobile-picker">
+        <Controller
+          name={name}
+          control={control}
+          render={({ field }) => {
+            const selectedDate =
+              field.value instanceof Date
+                ? field.value
+                : field.value
+                  ? new Date(field.value)
+                  : null;
+            const validDate =
+              selectedDate && !isNaN(selectedDate.getTime())
+                ? selectedDate
+                : null;
+            return (
+            <>
+              <DatePicker
+                selected={validDate}
+                onChange={(date: Date | null) => {
+                  field.onChange(date ? toDateString(date) : "");
+                }}
+                maxDate={maxDate ? new Date(maxDate) : undefined}
+                showMonthDropdown
+                showYearDropdown
+                dropdownMode="select"
+                dateFormat="MM/dd/yyyy"
+                placeholderText="MM/DD/YYYY"
+                autoComplete="off"
+                onChangeRaw={(e) => e.preventDefault()}
+                className={baseInputClass}
+                wrapperClassName="w-full"
+              />
+              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-400">
+                <Icon name="Calendar" size={16} />
               </span>
-            )}
-          </>
-        )}
-      />
+            </>
+            );
+          }}
+        />
+      </div>
+
+      {(error || helperText || reserveHelperSpace) && (
+        <p
+          className={`text-xs leading-4 min-h-4 ${
+            error ? "text-red-500" : "text-muted-foreground"
+          }`}
+        >
+          {error || helperText || ""}
+        </p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

### TM-1098 — Date Picker Mobile UI Fix
- Enhanced the shared `InputDatePicker` component with dual-mode rendering:
  - **Mobile (< sm):** Uses `react-datepicker` with brand blue theme, `MM/DD/YYYY` placeholder, month/year dropdowns with visible white chevrons
  - **Desktop (sm+):** Keeps native `<input type="date">` with calendar icon and `showPicker()` on click
- Field is non-editable on both views — clicking opens the calendar only (no direct typing)
- `caret-transparent` hides the blinking text cursor on mobile focus
- Applied to both **Register as a Tutor** (`PersonalInfo.tsx`) and **Tutor Profile** (`form-general-information/index.tsx`)
- Added `.dob-mobile-picker` CSS theme in `globals.css`

### UI Improvement — Home Page Cards
- Smoothed the hover transition on "Why Choose Home Tuition?" cards from `duration-300` → `duration-700 ease-in-out` for a more polished feel

## Files Changed
- `src/components/shared/input-date-picker/index.tsx`
- `src/app/globals.css`
- `src/app/[locale]/register-tutor/components/PersonalInfo.tsx`
- `src/app/[locale]/profile/[id]/components/form-general-information/index.tsx`
- `src/components/home-page/about-us/index.tsx`
- `pnpm-lock.yaml`

## Test Plan
- [ ] Register tutor → Personal Info → Date of Birth shows `MM/DD/YYYY` on mobile, opens blue calendar on tap
- [ ] Register tutor → selecting a date updates Age field automatically
- [ ] Tutor profile → Date of Birth shows existing date, calendar opens to correct month/year on mobile
- [ ] Desktop date picker unchanged — calendar icon click opens native picker
- [ ] Field not directly typeable on both mobile and desktop
- [ ] Home page → hover over "Why Choose Home Tuition?" cards shows smooth 700ms transition

## Jira
[TM-1098 — Date picker UI color is inconsistent](https://tutorme.atlassian.net/browse/TM-1098)