### PR TITLE
fix: Date of Birth validation error persistence and Gender options consistency in Tutor Profile

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
@@ -74,7 +74,6 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
     () => [
       { value: "Male", label: t("optGenderMale") },
       { value: "Female", label: t("optGenderFemale") },
-      { value: "Others", label: t("optGenderOthers") },
     ],
     [t],
   );

--- a/src/app/[locale]/register-tutor/components/PersonalInfo.tsx
+++ b/src/app/[locale]/register-tutor/components/PersonalInfo.tsx
@@ -101,6 +101,8 @@ const PersonalInfo = () => {
   useEffect(() => {
     if (!dateOfBirth) return;
 
+    trigger("dateOfBirth");
+
     const dob = new Date(dateOfBirth);
     const today = new Date();
 
@@ -114,7 +116,7 @@ const PersonalInfo = () => {
     if (age >= 0) {
       setValue("age", age, { shouldValidate: true });
     }
-  }, [dateOfBirth, setValue]);
+  }, [dateOfBirth, setValue, trigger]);
 
   useEffect(() => {
     const normalizedEmail =


### PR DESCRIPTION
## Summary

- **TM-1132** — Fixed Date of Birth validation error not clearing after a valid date is selected on the Register as a Tutor form
- **Gender fix** — Removed "Others" option from the Gender dropdown in Tutor Profile to align with Register as a Tutor (Male / Female only)

---

## Changes by Fix

### TM-1132 — Date of Birth error persists after valid date is selected

**File:** `src/app/[locale]/register-tutor/components/PersonalInfo.tsx`

- Added `trigger("dateOfBirth")` inside the existing `useEffect` that watches `dateOfBirth`
- When the user selects a valid date, `trigger` forces react-hook-form to revalidate the field immediately, clearing the error without requiring another click on Next
- No changes to the shared `InputDatePicker` component — fix is scoped to `PersonalInfo.tsx` only
- Added `trigger` to the `useEffect` dependency array

### Gender Options — Remove "Others" from Tutor Profile

**File:** `src/app/[locale]/profile/[id]/components/form-general-information/index.tsx`

- Removed `{ value: "Others", label: t("optGenderOthers") }` from `genderOptions`
- Tutor Profile Gender dropdown now shows Male and Female only, consistent with Register as a Tutor

---

## Files Changed

| File | Ticket | Change |
|---|---|---|
| `register-tutor/components/PersonalInfo.tsx` | TM-1132 | `trigger("dateOfBirth")` on value change |
| `profile/[id]/components/form-general-information/index.tsx` | — | Remove Others from gender options |

---

## Test Plan

- [ ] **TM-1132** — On Register as a Tutor, leave Date of Birth empty and click Next — error "Date of Birth is required" appears
- [ ] **TM-1132** — Select any valid date from the date picker — error clears immediately without clicking Next again
- [ ] **TM-1132** — Age field auto-calculates correctly after date selection
- [ ] **Gender** — Open Gender dropdown on Tutor Profile — only Male and Female options are visible, Others is gone
- [ ] **Gender** — Open Gender dropdown on Register as a Tutor — only Male and Female options shown (unchanged)