### PR TITLE
fix: restore required field asterisk indicators across Tutor Profile tabs and update Past Exam Papers pagination

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
@@ -430,6 +430,7 @@ const FormEducationInfo: FC<Props> = ({
                 options={highestEducationOptions}
                 placeholder={tR("highestEducationPlaceholder")}
                 className={fieldControlHeightClass}
+                required
                 reserveHelperSpace
               />
 

--- a/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-general-information/index.tsx
@@ -174,6 +174,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 placeholder={t("placeholderFullName")}
                 name="name"
                 type="text"
+                required
                 onChange={(e) => {
                   const cleaned = stripLeadingSpaces(e.target.value);
                   if (cleaned !== e.target.value) {
@@ -201,6 +202,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 placeholder={t("placeholderContactNumber")}
                 name="phoneNumber"
                 type="tel"
+                required
                 inputMode="numeric"
                 maxLength={10}
                 onKeyDown={preventWhitespaceKey}
@@ -244,6 +246,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 options={genderOptions}
                 placeholder={genderPlaceholder}
                 className={fieldHeightClass}
+                required
               />
               <InputSelect
                 label={t("fieldNationality")}
@@ -251,6 +254,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 options={nationalityOptions}
                 placeholder={nationalityPlaceholder}
                 className={fieldHeightClass}
+                required
               />
               <InputSelect
                 label={t("fieldRace")}
@@ -258,6 +262,7 @@ const FormGeneralInfo: FC<Props> = ({ form, onFormSubmit, isSubmitting }) => {
                 options={raceOptions}
                 placeholder={racePlaceholder}
                 className={fieldHeightClass}
+                required
               />
             </div>
             <div className="col-span-6 sm:col-full">

--- a/src/app/[locale]/profile/[id]/components/form-password-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-password-information/index.tsx
@@ -102,6 +102,7 @@ const FormPasswordInfo: FC = () => {
               label={t("fieldCurrentPassword")}
               name="currentPassword"
               placeholder={t("placeholderCurrentPassword")}
+              required
               onKeyDown={preventWhitespaceKey}
               onChange={sanitizePasswordField("currentPassword")}
             />
@@ -109,6 +110,7 @@ const FormPasswordInfo: FC = () => {
               label={t("fieldNewPassword")}
               name="newPassword"
               placeholder={t("placeholderNewPassword")}
+              required
               onKeyDown={preventWhitespaceKey}
               onChange={sanitizePasswordField("newPassword")}
             />
@@ -116,6 +118,7 @@ const FormPasswordInfo: FC = () => {
               label={t("fieldConfirmPassword")}
               name="confirmPassword"
               placeholder={t("placeholderConfirmPassword")}
+              required
               onKeyDown={preventWhitespaceKey}
               onChange={sanitizePasswordField("confirmPassword")}
             />

--- a/src/components/shared/input-password/index.tsx
+++ b/src/components/shared/input-password/index.tsx
@@ -7,10 +7,11 @@ interface InputPasswordProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   helperText?: string;
   name: string;
+  required?: boolean;
 }
 
 const InputPassword: React.FC<InputPasswordProps> = React.memo(
-  ({ label, helperText, className = "", name, onBlur, onChange, ...props }) => {
+  ({ label, helperText, className = "", name, required = false, onBlur, onChange, ...props }) => {
     const { control, formState } = useFormContext();
     const [showPassword, setShowPassword] = useState(false);
 
@@ -30,7 +31,10 @@ const InputPassword: React.FC<InputPasswordProps> = React.memo(
                 <span className="text-red-500"> *</span>
               </>
             ) : (
-              label
+              <>
+                {label}
+                {required && <span className="text-red-500"> *</span>}
+              </>
             )}
           </label>
         )}

--- a/src/components/shared/input-select/index.tsx
+++ b/src/components/shared/input-select/index.tsx
@@ -12,6 +12,7 @@ interface InputSelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   helperText?: string;
   options: Option[];
   name: string;
+  required?: boolean;
   loading?: boolean;
   placeholder?: string;
   disablePlaceholder?: boolean;
@@ -24,6 +25,7 @@ const InputSelect: FC<InputSelectProps> = ({
   options,
   name,
   className = "",
+  required = false,
   loading = false,
   placeholder = "Select an option",
   disablePlaceholder = true,
@@ -44,7 +46,10 @@ const InputSelect: FC<InputSelectProps> = ({
               <span className="text-red-500"> *</span>
             </>
           ) : (
-            label
+            <>
+              {label}
+              {required && <span className="text-red-500"> *</span>}
+            </>
           )}
         </label>
       )}

--- a/src/components/shared/input-text/index.tsx
+++ b/src/components/shared/input-text/index.tsx
@@ -6,6 +6,7 @@ interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   helperText?: string;
   name: string;
+  required?: boolean;
   reserveHelperSpace?: boolean;
 }
 
@@ -14,6 +15,7 @@ const InputText: React.FC<InputTextProps> = ({
   helperText,
   className = "",
   name,
+  required = false,
   onBlur,
   onChange,
   reserveHelperSpace = false,
@@ -32,7 +34,10 @@ const InputText: React.FC<InputTextProps> = ({
               <span className="text-red-500"> *</span>
             </>
           ) : (
-            label
+            <>
+              {label}
+              {required && <span className="text-red-500"> *</span>}
+            </>
           )}
         </label>
       )}

--- a/src/components/shared/pagination/index.tsx
+++ b/src/components/shared/pagination/index.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, FC, SetStateAction } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 type Props = {
   currentPage: number;
@@ -7,6 +8,38 @@ type Props = {
   className?: string;
   previousLabel?: string;
   nextLabel?: string;
+};
+
+const getPageNumbers = (
+  currentPage: number,
+  totalPages: number,
+): (number | "...")[] => {
+  if (totalPages <= 8) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const result: (number | "...")[] = [];
+
+  if (currentPage <= 5) {
+    for (let i = 1; i <= 7; i++) result.push(i);
+    result.push("...");
+    result.push(totalPages);
+    return result;
+  }
+
+  if (currentPage >= totalPages - 4) {
+    result.push(1);
+    result.push("...");
+    for (let i = totalPages - 6; i <= totalPages; i++) result.push(i);
+    return result;
+  }
+
+  result.push(1);
+  result.push("...");
+  for (let i = currentPage - 2; i <= currentPage + 2; i++) result.push(i);
+  result.push("...");
+  result.push(totalPages);
+  return result;
 };
 
 const Pagination: FC<Props> = ({
@@ -19,34 +52,52 @@ const Pagination: FC<Props> = ({
 }) => {
   if (totalPages <= 1) return null;
 
-  const goToPreviousPage = () => {
-    onPageChange(Math.max(currentPage - 1, 1));
-  };
-
-  const goToNextPage = () => {
-    onPageChange(Math.min(currentPage + 1, totalPages));
-  };
+  const pages = getPageNumbers(currentPage, totalPages);
 
   return (
-    <div className={`flex justify-center items-center gap-2 ${className}`}>
+    <div className={`flex justify-center items-center gap-1 ${className}`}>
       <button
         type="button"
         disabled={currentPage === 1}
-        onClick={goToPreviousPage}
-        className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+        onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+        className="flex items-center gap-1 px-3 py-2 text-sm rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition"
       >
+        <ChevronLeft size={15} />
         {previousLabel}
       </button>
-      <span className="text-sm text-gray-500 px-2">
-        {currentPage} / {totalPages}
-      </span>
+
+      {pages.map((page, index) =>
+        page === "..." ? (
+          <span
+            key={`ellipsis-${index}`}
+            className="px-2 py-2 text-sm text-gray-400 select-none"
+          >
+            ...
+          </span>
+        ) : (
+          <button
+            key={page}
+            type="button"
+            onClick={() => onPageChange(page)}
+            className={`min-w-[36px] h-9 px-2 text-sm rounded-lg font-medium transition ${
+              page === currentPage
+                ? "bg-blue-600 text-white"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
+          >
+            {page}
+          </button>
+        ),
+      )}
+
       <button
         type="button"
         disabled={currentPage === totalPages}
-        onClick={goToNextPage}
-        className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+        onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
+        className="flex items-center gap-1 px-3 py-2 text-sm rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition"
       >
         {nextLabel}
+        <ChevronRight size={15} />
       </button>
     </div>
   );


### PR DESCRIPTION
## Overview

This PR restores missing required field asterisk (*) indicators across all 
Tutor Profile tabs following the TM-1123 cleanup, and replaces the fractional 
pagination on Past Exam Papers with a numbered button style.

---

## Changes

### Required Asterisk Indicators — Shared Components

**Files:**
- `src/components/shared/input-text/index.tsx`
- `src/components/shared/input-select/index.tsx`
- `src/components/shared/input-password/index.tsx`

**Root cause:** TM-1123 correctly removed ` *` suffixes from translation 
strings to fix duplicate asterisks. However, all three shared components 
relied on detecting `*` in the label string to render the red asterisk — 
removing it from translations broke the display entirely.

**Fix:** Added a `required` boolean prop (defaults to `false`) to all three 
components. When `required={true}`, renders `<span class="text-red-500"> *</span>` 
alongside the label. Fully backward-compatible — no existing usages are affected.

---

### Required Asterisk Indicators — Tutor Profile Forms

**Files:**
- `profile/[id]/components/form-general-information/index.tsx`
- `profile/[id]/components/form-education-information/index.tsx`
- `profile/[id]/components/form-password-information/index.tsx`

**Personal Information tab** — added `required` to:
- Full Name, Contact Number, Gender, Nationality, Race
- Email and Age intentionally excluded (read-only / auto-calculated)

**Qualifications tab** — added `required` to:
- Highest Education Level

**Security tab** — added `required` to:
- Current Password, New Password, Confirm Password

---

### Past Exam Papers — Numbered Pagination

**File:** `src/components/shared/pagination/index.tsx`

Replaced the `1 / 244` text block with individual clickable page number 
buttons and chevron Previous / Next controls.

**Pagination behaviour:**
- Pages 1–5 → shows first 7 pages then ellipsis then last page: `1 2 3 4 5 6 7 ... 244`
- Middle pages → shows first, ellipsis, ±2 around current, ellipsis, last: `1 ... 8 9 10 11 12 ... 244`
- Last 5 pages → shows first then ellipsis then last 7 pages: `1 ... 238 239 240 241 242 243 244`
- 8 or fewer total pages → all page numbers shown with no ellipsis
- Active page highlighted in blue, Previous/Next include chevron icons

---

## Files Changed

| File | Change |
|---|---|
| `shared/input-text/index.tsx` | Added `required` prop |
| `shared/input-select/index.tsx` | Added `required` prop |
| `shared/input-password/index.tsx` | Added `required` prop |
| `form-general-information/index.tsx` | `required` on 5 mandatory fields |
| `form-education-information/index.tsx` | `required` on Highest Education Level |
| `form-password-information/index.tsx` | `required` on 3 password fields |
| `shared/pagination/index.tsx` | Numbered buttons with ellipsis |

---

## Test Plan

- [ ] Tutor Profile → Personal Information tab — Full Name, Contact Number, Gender, Nationality, Race all show red asterisk
- [ ] Tutor Profile → Personal Information tab — Email and Age do NOT show asterisk (read-only fields)
- [ ] Tutor Profile → Qualifications tab — Highest Education Level shows red asterisk
- [ ] Tutor Profile → Security tab — Current Password, New Password, Confirm Password all show red asterisk
- [ ] Past Exam Papers — pagination shows numbered buttons (1 2 3 4 5 6 7 ... 244) on first page
- [ ] Past Exam Papers — clicking a page number navigates to that page and highlights it in blue
- [ ] Past Exam Papers — Previous/Next buttons work correctly and disable at boundaries
- [ ] No regressions on any other form that uses InputText, InputSelect, or InputPassword without the `required` prop