### PR TITLE
fix: optional document validation for register tutor and tutor profile (TM-1137, TM-1153)

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
@@ -6,6 +6,7 @@ import {
   FormProvider,
   SubmitHandler,
   useFieldArray,
+  useFormContext,
 } from "react-hook-form";
 import InputSelect from "@/components/shared/input-select";
 import MultiSelect from "@/components/shared/MultiSelect";
@@ -71,6 +72,7 @@ const DocumentRow = ({
   selectTypePlaceholder: string;
   uploadLabels?: Record<string, string | ((fileName: string) => string)>;
 }) => {
+  const { trigger } = useFormContext();
   const rowErrors = errors[index] ?? {};
   return (
     <div className="grid grid-cols-1 md:grid-cols-[220px_1fr_auto] gap-3 items-start p-3 rounded-lg border border-gray-200 bg-gray-50">
@@ -84,6 +86,10 @@ const DocumentRow = ({
           render={({ field: f }) => (
             <select
               {...f}
+              onChange={(e) => {
+                f.onChange(e);
+                trigger(`${fieldName}.${index}.type`);
+              }}
               className={`${selectClass} ${selectBorder(!!rowErrors.type)} ${selectColor(f.value)}`}
             >
               <option value="" disabled hidden>
@@ -116,7 +122,10 @@ const DocumentRow = ({
           render={({ field: f }) => (
             <MultiFileUploadDropzone
               initialUrls={f.value ? [f.value] : []}
-              onUploaded={(urls) => f.onChange(urls[urls.length - 1] ?? "")}
+              onUploaded={(urls) => {
+                f.onChange(urls[urls.length - 1] ?? "");
+                trigger(`${fieldName}.${index}.url`);
+              }}
               labels={uploadLabels as any}
             />
           )}
@@ -250,7 +259,7 @@ const FormEducationInfo: FC<Props> = ({
     (s) => [s.label],
     (s, [label]) => ({ ...s, label: label ?? s.label }),
   );
-  const { isDirty, isValid } = form.formState;
+  const { isDirty } = form.formState;
 
   const {
     fields: eduFields,
@@ -272,6 +281,8 @@ const FormEducationInfo: FC<Props> = ({
 
   const certErrors =
     (form.formState.errors.certificatesAndQualifications as any) ?? [];
+  const optErrors =
+    (form.formState.errors.optionalCertificates as any) ?? [];
 
   const [
     classType,
@@ -328,7 +339,7 @@ const FormEducationInfo: FC<Props> = ({
     Array.isArray(certificatesAndQualifications) &&
     certificatesAndQualifications.length > 0;
   const isButtonDisabled =
-    !isDirty || isSubmitting || !hasAllRequiredFields || !isValid;
+    !isDirty || isSubmitting || !hasAllRequiredFields;
 
   return (
     <div className="mb-4 rounded-2xl bg-white p-4 shadow-sm sm:rounded-3xl sm:p-6 2xl:col-span-2">
@@ -595,7 +606,7 @@ const FormEducationInfo: FC<Props> = ({
                         index={index}
                         options={optionalDocumentOptions}
                         control={form.control}
-                        errors={[]}
+                        errors={optErrors}
                         onRemove={() => removeOpt(index)}
                         removable={true}
                         documentTypeLabel={t("documentTypeLabel")}

--- a/src/app/[locale]/profile/[id]/components/form-education-information/schema.ts
+++ b/src/app/[locale]/profile/[id]/components/form-education-information/schema.ts
@@ -39,10 +39,30 @@ export const createEducationInfoSchema = (t: (_key: string) => string) =>
         .min(1, t("certificatesRequired")),
       optionalCertificates: z
         .array(
-          z.object({
-            type: z.string(),
-            url: z.string(),
-          }),
+          z
+            .object({
+              type: z.string(),
+              url: z.string(),
+            })
+            .superRefine((doc, ctx) => {
+              const hasType = !!doc.type.trim();
+              const hasUrl = !!doc.url.trim();
+              if (!hasType && !hasUrl) return;
+              if (hasType && !hasUrl) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: t("uploadRequired"),
+                  path: ["url"],
+                });
+              }
+              if (!hasType && hasUrl) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: t("documentTypeRequired"),
+                  path: ["type"],
+                });
+              }
+            }),
         )
         .optional()
         .default([]),

--- a/src/app/[locale]/register-tutor/components/TermsAndSubmit.tsx
+++ b/src/app/[locale]/register-tutor/components/TermsAndSubmit.tsx
@@ -10,7 +10,6 @@ import { useTranslations } from "next-intl";
 import { useMemo, type ComponentProps } from "react";
 
 import MultiFileUploadDropzone from "@/components/upload/multi-file-upload-dropzone";
-import MultiSelect from "@/components/shared/MultiSelect";
 
 const DocumentRow = ({
   fieldName,
@@ -49,17 +48,21 @@ const DocumentRow = ({
           control={control}
           render={({ field: f, fieldState }) => (
             <>
-              <MultiSelect
-                options={options}
-                defaultSelected={f.value ? [f.value] : []}
-                onChange={(selected) => {
-                  f.onChange(selected[0] ?? "");
+              <select
+                {...f}
+                onChange={(e) => {
+                  f.onChange(e);
                   trigger(`${fieldName}.${index}.type`);
                 }}
-                hasError={!!fieldState.error}
-                singleSelect
-                placeholder={selectTypePlaceholder}
-              />
+                className={`h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring ${fieldState.error ? "border-red-500" : "border-gray-300"} ${f.value ? "text-gray-900" : "text-gray-500"}`}
+              >
+                <option value="" disabled hidden>{selectTypePlaceholder}</option>
+                {options.map((opt) => (
+                  <option key={opt.value} value={opt.value} className="text-gray-900">
+                    {opt.text}
+                  </option>
+                ))}
+              </select>
               {fieldState.error && (
                 <p className="text-xs text-red-500">{fieldState.error.message}</p>
               )}

--- a/src/app/[locale]/register-tutor/schema.ts
+++ b/src/app/[locale]/register-tutor/schema.ts
@@ -245,10 +245,30 @@ const createStep4Schema = (t: (_key: string) => string) =>
       .min(1, t("documentRequired")),
     optionalCertificates: z
       .array(
-        z.object({
-          type: z.string(),
-          url: z.string(),
-        }),
+        z
+          .object({
+            type: z.string(),
+            url: z.string(),
+          })
+          .superRefine((doc, ctx) => {
+            const hasType = !!doc.type.trim();
+            const hasUrl = !!doc.url.trim();
+            if (!hasType && !hasUrl) return;
+            if (hasType && !hasUrl) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: t("uploadRequired"),
+                path: ["url"],
+              });
+            }
+            if (!hasType && hasUrl) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: t("documentTypeRequired"),
+                path: ["type"],
+              });
+            }
+          }),
       )
       .optional()
       .default([]),


### PR DESCRIPTION
## Summary
- Added conditional validation to optional certificate rows in both Register as a Tutor and Tutor Profile forms
- Replaced MultiSelect with a native select for document type in the register form to match profile UI

## Validation Behaviour (both forms now consistent)
- Empty row (accidental Add Document click) → form stays valid, submits fine, empty row is ignored
- Document type selected, no file uploaded → error shown immediately: "Please upload a file"
- File uploaded, no document type selected → error shown immediately: "Document type is required"
- Both fields filled → valid, submits normally

## Changes

**Register as a Tutor**
- `schema.ts` — replaced plain `z.string()` with `superRefine` conditional check on `optionalCertificates`: both-empty rows pass, partial rows fail with field-level errors
- `TermsAndSubmit.tsx` — replaced `MultiSelect` with native `<select>` for document type dropdown to match profile form UI

**Tutor Profile**
- `schema.ts` — same `superRefine` conditional validation as register form
- `index.tsx` — added `useFormContext` to access `trigger`; errors now fire immediately on field change (same as register form); wired `optErrors` to optional document rows instead of hardcoded `[]`; removed `!isValid` from button disabled check so button stays enabled with partial optional rows and errors show on submit click

## Fixes
- TM-1137: Update Qualifications button disabled incorrectly when optional details incomplete
- TM-1153: Optional document type submittable without uploading a file