### PR TITLE
feat: Replace default profile avatar with user initial circle (profile & navbar)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -615,6 +615,7 @@
     "changePhotoDesc": "JPG, PNG or GIF - Max 800KB",
     "cancel": "Cancel",
     "save": "Save",
+    "removePhoto": "Remove photo",
     "removePhotoTitle": "Remove profile picture?",
     "removePhotoDesc": "This will permanently remove your current profile photo.",
     "delete": "Delete",

--- a/messages/si.json
+++ b/messages/si.json
@@ -615,6 +615,7 @@
     "changePhotoDesc": "JPG, PNG හෝ GIF - උපරිම 800KB",
     "cancel": "අවලංගු කරන්න",
     "save": "සුරකින්න",
+    "removePhoto": "රූපය ඉවත් කරන්න",
     "removePhotoTitle": "පැතිකඩ රූපය ඉවත් කරන්නද?",
     "removePhotoDesc": "මෙය ඔබේ වත්මන් පැතිකඩ ඡායාරූපය ස්ථිරවම ඉවත් කරයි.",
     "delete": "මකන්න",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -615,6 +615,7 @@
     "changePhotoDesc": "JPG, PNG அல்லது GIF - அதிகபட்சம் 800KB",
     "cancel": "ரத்து செய்",
     "save": "சேமி",
+    "removePhoto": "படத்தை நீக்கு",
     "removePhotoTitle": "சுயவிவர புகைப்படம் நீக்கவா?",
     "removePhotoDesc": "இது உங்கள் தற்போதைய சுயவிவர புகைப்படத்தை நிரந்தரமாக நீக்கும்.",
     "delete": "நீக்கு",

--- a/src/app/[locale]/profile/[id]/components/form-profile-pic-settings/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-profile-pic-settings/index.tsx
@@ -9,7 +9,7 @@ import {
   useUpdateProfileMutation,
 } from "@/store/api/splits/users";
 import toast from "react-hot-toast";
-import { Pencil, Trash2 } from "lucide-react";
+import { Camera, Pencil, Trash2 } from "lucide-react";
 
 const DEFAULT_AVATAR = "/images/profile/pp.png";
 
@@ -95,19 +95,34 @@ const ProfilePicSettings = () => {
       </div>
 
       <div className="flex justify-center">
-        <div className="relative h-28 w-28 sm:h-36 sm:w-36">
-          <img
-            src={avatarUrl}
-            alt="User profile picture"
-            className="h-full w-full rounded-full border object-cover"
-          />
+        <div className="relative h-28 w-28 sm:h-36 sm:w-36 group">
+          {hasProfilePicture ? (
+            <img
+              src={avatarUrl}
+              alt="User profile picture"
+              className="h-full w-full rounded-full border object-cover"
+            />
+          ) : (
+            <div className="h-full w-full rounded-full border border-primary-200 bg-primary-100 flex items-center justify-center select-none">
+              <span className="text-5xl sm:text-6xl font-bold text-primary-700 uppercase leading-none">
+                {(user?.name || user?.email || "?").charAt(0)}
+              </span>
+            </div>
+          )}
+
+          <div
+            onClick={() => setOpen(true)}
+            className="absolute inset-0 rounded-full bg-black/25 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center cursor-pointer"
+          >
+            <Camera size={26} className="text-white" />
+          </div>
 
           <button
             onClick={() => setOpen(true)}
             className="absolute bottom-1 right-1 rounded-full bg-white p-2 shadow transition-colors hover:bg-gray-100 sm:p-2.5"
             aria-label="Edit profile picture"
           >
-            <Pencil size={16} className="sm:h-[18px] sm:w-[18px]" />
+            <Pencil size={14} className="sm:h-4 sm:w-4" />
           </button>
 
           <button
@@ -116,22 +131,13 @@ const ProfilePicSettings = () => {
                 toast.error(t("noProfilePicture"));
                 return;
               }
-
               setConfirmDeleteOpen(true);
             }}
             disabled={!hasProfilePicture || isLoading}
-            className="absolute bottom-1 left-1 rounded-full bg-white p-2 shadow transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 sm:p-2.5"
+            className="absolute bottom-1 left-1 rounded-full bg-white p-2 shadow transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 sm:p-2.5"
             aria-label="Delete profile picture"
-            title={
-              hasProfilePicture
-                ? "Delete profile picture"
-                : "No profile picture to remove"
-            }
           >
-            <Trash2
-              size={16}
-              className="text-red-600 sm:h-[18px] sm:w-[18px]"
-            />
+            <Trash2 size={14} className="text-red-500 sm:h-4 sm:w-4" />
           </button>
         </div>
       </div>

--- a/src/components/shared/navbar/profile-section.tsx
+++ b/src/components/shared/navbar/profile-section.tsx
@@ -149,11 +149,19 @@ const ProfileDropdown: FC<Props> = ({ isLoading, user }) => {
           className="flex items-center justify-center w-12 h-12 rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none"
           onClick={toggleDropdown}
         >
-          <img
-            src={avatarSrc}
-            alt="Profile-image"
-            className="w-10 h-10 rounded-full object-cover"
-          />
+          {avatarSrc !== DEFAULT_AVATAR ? (
+            <img
+              src={avatarSrc}
+              alt="Profile-image"
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center select-none">
+              <span className="text-base font-bold text-primary-700 uppercase leading-none">
+                {(user?.name || user?.email || "?").charAt(0)}
+              </span>
+            </div>
+          )}
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Replaces grey silhouette default avatar with a personalised circle showing the user's first initial (from `user.name`, fallback `user.email`)
- Applied consistently in Tutor Profile photo section and navbar profile button
- Uses existing palette colours — `bg-primary-100` background, `text-primary-700` text — no hardcoded values
- Camera hover overlay on avatar circle is clickable to open upload modal
- Edit (pencil) and delete (trash) overlay buttons remain visible; trash is dimmed when no photo exists
- Added `removePhoto` translation key across en/si/ta locales

## Test Plan
- [x] Tutor with no photo — initial circle appears in both navbar and Profile tab
- [ ] Initial is first letter of user's name, uppercase
- [ ] Hover over circle — camera overlay appears; clicking opens upload modal
- [ ] Pencil button opens upload modal; trash button dimmed with no photo, opens confirm dialog with photo
- [ ] Upload photo → real photo replaces initial circle in both locations
- [ ] Remove photo → initial circle returns
- [ ] Verify on mobile — circle and buttons render correctly
- [ ] Check all three locales (EN / SI / TA)