### PR TITLE
Feature/tm 1163 1164 1165 1166 UI fixes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -425,7 +425,7 @@
   },
   "pastExamPapers": {
     "pageHeading": "Download Sri Lankan Past Exam Papers for Free",
-    "pageSubheading": "Grade 5 Scholarship, O/L, A/L & Grade 1–13. Explore a complete database of Sri Lanka past exam papers, including Grade 5 Scholarship papers, GCE O/L past papers, and GCE A/L past papers. Download free model papers, school test papers, and previous exam questions for all grades and subjects.",
+    "pageSubheading": "Download free Sri Lankan Grade 1–13 past exam papers, including Grade 5 Scholarship, GCE O/L, GCE A/L, model papers, and school term test papers for all subjects and mediums from TuitionLanka",
     "sectionHeading": "Download Past Exam Papers",
     "edexcelHeading": "Edexcel Past Papers",
     "edexcelBody1": "Due to copyright restrictions, we are unable to share Edexcel past papers on our website.",

--- a/src/app/[locale]/past-exam-papers/page.tsx
+++ b/src/app/[locale]/past-exam-papers/page.tsx
@@ -256,10 +256,10 @@ const TestPapers = () => {
   );
 
   return (
-    <div className="max-w-7xl mx-auto py-10">
+    <div className="max-w-7xl mx-auto pb-6 sm:py-10">
       <div className=" py-4 m-3">
-        <h2 className="text-4xl font-bold text-center">{t("pageHeading")}</h2>
-        <h3 className="mx-auto mt-3 max-w-2xl text-xl font-normal text-center opacity-50">
+        <h2 className="text-3xl font-bold text-center">{t("pageHeading")}</h2>
+        <h3 className="mx-auto mt-3 max-w-2xl px-4 sm:px-0 text-sm md:text-base font-normal text-center opacity-50">
           {t("pageSubheading")}
         </h3>
       </div>

--- a/src/app/[locale]/profile/[id]/hooks/useLogic.tsx
+++ b/src/app/[locale]/profile/[id]/hooks/useLogic.tsx
@@ -3,7 +3,7 @@
 import { useAuthContext } from "@/contexts";
 import {
   useFetchGradesQuery,
-  useLazyFetchGradeByIdQuery,
+  useFetchSubjectsForGradesMutation,
 } from "@/store/api/splits/grades";
 import {
   useLazyGetProfileQuery,
@@ -11,7 +11,7 @@ import {
 } from "@/store/api/splits/users";
 import { useLazyGetTutorRegistrationQuery } from "@/store/api/splits/tutor-request";
 import { Option } from "@/types/shared-types";
-import { ProfileResponse, Subject } from "@/types/response-types";
+import { ProfileResponse } from "@/types/response-types";
 import { getErrorInApiResult } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { size } from "lodash-es";
@@ -590,7 +590,7 @@ const useLogic = (): LogicReturnType => {
     },
   );
 
-  const [fetchSubjectsByGrade] = useLazyFetchGradeByIdQuery();
+  const [fetchSubjectsForGrades] = useFetchSubjectsForGradesMutation();
   const [handleProfileSubmit, { isLoading: isGeneralFormSubmitting }] =
     useUpdateProfileMutation();
 
@@ -620,8 +620,6 @@ const useLogic = (): LogicReturnType => {
 
   const [selectedEducationGrades] = educationInfoForm.watch(["grades"]);
 
-  const educationGradeSubjectsMapRef = useRef<Map<string, string[]>>(new Map());
-  const prevEducationGradesRef = useRef<string[]>([]);
   const hasInitialEducationSubjectsBeenSet = useRef(false);
   const currentUserId = user?.id;
   const userRole = user?.role;
@@ -790,79 +788,33 @@ const useLogic = (): LogicReturnType => {
 
   const syncEducationSubjectOptions = useCallback(async () => {
     const currentGrades: string[] = selectedEducationGrades ?? [];
-    const prevGrades = prevEducationGradesRef.current;
 
-    const removedGrades = prevGrades.filter(
-      (gradeId) => !currentGrades.includes(gradeId),
-    );
+    if (currentGrades.length === 0) {
+      setEducationSubjectsOptions([]);
+      educationInfoForm.setValue("subjects", [], { shouldDirty: true });
+      return;
+    }
 
-    if (removedGrades.length > 0) {
-      const removedSubjectIds = new Set<string>();
+    try {
+      const result = await fetchSubjectsForGrades({ gradeIds: currentGrades }).unwrap();
+      const newOptions = (result.subjects ?? []).map(({ title, id }) => ({
+        label: title,
+        value: id,
+      }));
 
-      removedGrades.forEach((gradeId) => {
-        (educationGradeSubjectsMapRef.current.get(gradeId) ?? []).forEach(
-          (subjectId) => removedSubjectIds.add(subjectId),
-        );
-        educationGradeSubjectsMapRef.current.delete(gradeId);
-      });
+      setEducationSubjectsOptions(newOptions);
 
-      // Keep subjects that still belong to a remaining selected grade
-      currentGrades.forEach((gradeId) => {
-        (educationGradeSubjectsMapRef.current.get(gradeId) ?? []).forEach(
-          (subjectId) => removedSubjectIds.delete(subjectId),
-        );
-      });
-
-      setEducationSubjectsOptions((prev) =>
-        prev.filter((option) => !removedSubjectIds.has(option.value)),
-      );
-
+      const validIds = new Set(newOptions.map((o) => o.value));
       const currentSubjects = educationInfoForm.getValues("subjects") ?? [];
       educationInfoForm.setValue(
         "subjects",
-        currentSubjects.filter(
-          (subjectId) => !removedSubjectIds.has(subjectId),
-        ),
+        currentSubjects.filter((id) => validIds.has(id)),
         { shouldDirty: true },
       );
+    } catch {
+      toast.error("Failed to load subjects");
     }
-
-    for (const gradeId of currentGrades) {
-      if (educationGradeSubjectsMapRef.current.has(gradeId)) continue;
-
-      const result = await fetchSubjectsByGrade(gradeId);
-      const error = getErrorInApiResult(result);
-
-      if (error) {
-        toast.error(error);
-        continue;
-      }
-
-      if (result.data) {
-        const existingIds = new Set(
-          Array.from(educationGradeSubjectsMapRef.current.values()).flat(),
-        );
-        const newSubjects: Subject[] = result.data.subjects.filter(
-          ({ id }) => !existingIds.has(id),
-        );
-
-        educationGradeSubjectsMapRef.current.set(
-          gradeId,
-          result.data.subjects.map(({ id }) => id),
-        );
-
-        setEducationSubjectsOptions((prev) => [
-          ...prev,
-          ...newSubjects.map(({ title, id }) => ({
-            label: title,
-            value: id,
-          })),
-        ]);
-      }
-    }
-
-    prevEducationGradesRef.current = currentGrades;
-  }, [educationInfoForm, fetchSubjectsByGrade, selectedEducationGrades]);
+  }, [educationInfoForm, fetchSubjectsForGrades, selectedEducationGrades]);
 
   useEffect(() => {
     if (

--- a/src/app/[locale]/register-tutor/components/TermsAndSubmit.tsx
+++ b/src/app/[locale]/register-tutor/components/TermsAndSubmit.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { useMemo, type ComponentProps } from "react";
 
 import MultiFileUploadDropzone from "@/components/upload/multi-file-upload-dropzone";
+import MultiSelect from "@/components/shared/MultiSelect";
 
 const DocumentRow = ({
   fieldName,
@@ -48,21 +49,17 @@ const DocumentRow = ({
           control={control}
           render={({ field: f, fieldState }) => (
             <>
-              <select
-                {...f}
-                onChange={(e) => {
-                  f.onChange(e);
+              <MultiSelect
+                options={options}
+                defaultSelected={f.value ? [f.value] : []}
+                onChange={(selected) => {
+                  f.onChange(selected[0] ?? "");
                   trigger(`${fieldName}.${index}.type`);
                 }}
-                className={`h-11 w-full rounded-md border bg-transparent px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring ${fieldState.error ? "border-red-500" : "border-gray-300"} ${f.value ? "text-gray-900" : "text-gray-500"}`}
-              >
-                <option value="" disabled hidden>{selectTypePlaceholder}</option>
-                {options.map((opt) => (
-                  <option key={opt.value} value={opt.value} className="text-gray-900">
-                    {opt.text}
-                  </option>
-                ))}
-              </select>
+                hasError={!!fieldState.error}
+                singleSelect
+                placeholder={selectTypePlaceholder}
+              />
               {fieldState.error && (
                 <p className="text-xs text-red-500">
                   {fieldState.error.message}

--- a/src/app/[locale]/tuition-rates/page.tsx
+++ b/src/app/[locale]/tuition-rates/page.tsx
@@ -8,10 +8,10 @@ const TuitionRatesPage = () => {
   const t = useTranslations("tuitionRates");
 
   return (
-    <div className="m-10">
-      <div className="mx-auto max-w-7xl py-4 m-3">
-        <h2 className="text-4xl font-bold text-center">{t("pageHeading")}</h2>
-        <h3 className="mx-auto mt-3 max-w-2xl text-xl font-normal text-center opacity-50 mb-12">
+    <div className="px-4 lg:px-8">
+      <div className="mx-auto max-w-7xl pb-6 sm:py-10">
+        <h2 className="text-3xl font-bold text-center">{t("pageHeading")}</h2>
+        <h3 className="mx-auto mt-3 max-w-2xl px-4 sm:px-0 text-sm md:text-base font-normal text-center opacity-50 mb-12">
           {t("pageSubheading")}
         </h3>
         <TuitionRatesByLevel />

--- a/src/app/[locale]/tuition-rates/page.tsx
+++ b/src/app/[locale]/tuition-rates/page.tsx
@@ -9,7 +9,7 @@ const TuitionRatesPage = () => {
 
   return (
     <div className="px-4 lg:px-8">
-      <div className="mx-auto max-w-7xl pb-6 sm:py-10">
+      <div className="mx-auto max-w-7xl py-6 sm:py-10">
         <h2 className="text-3xl font-bold text-center">{t("pageHeading")}</h2>
         <h3 className="mx-auto mt-3 max-w-2xl px-4 sm:px-0 text-sm md:text-base font-normal text-center opacity-50 mb-12">
           {t("pageSubheading")}

--- a/src/components/shared/navbar/drawer-component.tsx
+++ b/src/components/shared/navbar/drawer-component.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable unused-imports/no-unused-vars */
 
 import Link from "next/link";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import Icon from "../icon";
 import { AuthUserData } from "@/types/auth-types";
 import { useTranslations } from "next-intl";
+import ConfirmationAlert from "../confirm-alert";
+import { useAuthContext } from "@/contexts";
 
 interface DrawerProps {
   children: ReactNode;
@@ -24,6 +26,8 @@ const Drawer = ({
   logout,
 }: DrawerProps) => {
   const t = useTranslations("nav");
+  const { isUserLogoutLoading } = useAuthContext();
+  const [isLogoutConfirmationOpen, setIsLogoutConfirmationOpen] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -100,8 +104,7 @@ const Drawer = ({
               className="w-full block bg-blue-600 text-white hover:bg-blue-700 py-2 rounded-full text-center text-base font-semibold"
               onClick={() => {
                 if (user?.email) {
-                  logout?.();
-                  setIsOpen(false);
+                  setIsLogoutConfirmationOpen(true);
                 } else {
                   handleOnChangeSignUpModalVisibility();
                 }
@@ -112,6 +115,21 @@ const Drawer = ({
           </footer>
         </article>
       </section>
+
+      <ConfirmationAlert
+        isOpen={isLogoutConfirmationOpen}
+        closeModal={() => setIsLogoutConfirmationOpen(false)}
+        onConfirm={() => {
+          logout?.();
+          setIsOpen(false);
+          setIsLogoutConfirmationOpen(false);
+        }}
+        title={t("logout")}
+        description={t("logoutConfirmation")}
+        cancelText={t("cancel")}
+        confirmText={t("logout")}
+        loading={isUserLogoutLoading}
+      />
 
       {/* Backdrop */}
       <section

--- a/src/components/shared/number-stepper/index.tsx
+++ b/src/components/shared/number-stepper/index.tsx
@@ -62,12 +62,24 @@ const NumberStepper = ({
 
           return (
             <>
-              {/* Mobile: value on left, − + buttons grouped on right */}
+              {/* Mobile: − [input] + centered layout */}
               <div
-                className={`flex sm:hidden h-11 items-center overflow-hidden rounded-md border bg-white ${
+                className={`flex sm:hidden h-11 w-full items-center overflow-hidden rounded-md border bg-white ${
                   error ? "border-red-500" : "border-gray-300"
                 }`}
               >
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = Math.max(min, val - 1);
+                    field.onChange(next);
+                    if (next >= 1) clearErrors(name);
+                  }}
+                  disabled={val <= min}
+                  className="flex h-full w-10 shrink-0 items-center justify-center border-r border-gray-200 bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+                >
+                  −
+                </button>
                 <input
                   type="text"
                   inputMode="numeric"
@@ -75,34 +87,20 @@ const NumberStepper = ({
                   value={val}
                   onChange={handleChange}
                   onBlur={field.onBlur}
-                  className="h-full flex-1 border-0 bg-transparent px-3 text-sm font-medium text-gray-900 focus:outline-none focus:ring-0"
+                  className="h-full min-w-0 flex-1 border-0 bg-transparent text-center text-sm font-medium text-gray-900 focus:outline-none focus:ring-0"
                 />
-                <div className="flex h-full items-center border-l border-gray-200">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const next = Math.max(min, val - 1);
-                      field.onChange(next);
-                      if (next >= 1) clearErrors(name);
-                    }}
-                    disabled={val <= min}
-                    className="flex h-full w-11 items-center justify-center border-r border-gray-200 bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
-                  >
-                    −
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const next = Math.min(max, val + 1);
-                      field.onChange(next);
-                      clearErrors(name);
-                    }}
-                    disabled={val >= max}
-                    className="flex h-full w-11 items-center justify-center bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
-                  >
-                    +
-                  </button>
-                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = Math.min(max, val + 1);
+                    field.onChange(next);
+                    clearErrors(name);
+                  }}
+                  disabled={val >= max}
+                  className="flex h-full w-10 shrink-0 items-center justify-center border-l border-gray-200 bg-gray-50 text-lg font-semibold text-gray-500 hover:bg-gray-100 active:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+                >
+                  +
+                </button>
               </div>
 
               {/* Desktop (sm+): plain input matching other form fields */}


### PR DESCRIPTION
## Summary

This PR delivers four bug fixes (TM-1163, TM-1164, TM-1165, TM-1166) and two UI improvements across the client portal.

---

### TM-1163 — Tutor Profile: Subjects Only Showing for One Grade

**Problem:** When a tutor selected multiple grades, only subjects for the last-processed grade appeared. The previous implementation looped through grades one by one using `useLazyFetchGradeByIdQuery`, overwriting the subject list on each response.

**Fix:** Replaced the per-grade loop with a single `useFetchSubjectsForGradesMutation` call that sends all selected grade IDs in one POST request and returns subjects for all grades at once. Also removed the now-unused `educationGradeSubjectsMapRef` and `prevEducationGradesRef` refs, simplifying the component.

---

### TM-1164 — Register as Tutor: Years of Experience Stepper Misaligned on Mobile

**Problem:** The mobile stepper layout placed the number input on the left with both − and + buttons grouped on the right. On screens narrower than ~400px the number appeared disconnected from the buttons, with excessive whitespace in between.

**Fix:** Redesigned the mobile layout to the standard [−] [input] [+] pattern. The − button is pinned to the left with `w-10 shrink-0`, the input fills the centre with `flex-1 min-w-0 text-center`, and + is pinned to the right with `w-10 shrink-0`. This works at any screen width including 320px without overflow or compression.

---

### TM-1165 — Register as Tutor: Document Type Dropdown Shows Dark Theme on Mobile

**Problem:** The Document Type dropdown used a native HTML `<select>` element. On Android/iOS mobile browsers, the native select picker renders using the OS/browser theme, which appeared as a dark modal sheet — inconsistent with all other dropdowns in the form.

**Fix:** Replaced the native `<select>` with the custom `MultiSelect` component (with `singleSelect` prop), the same component used for Gender, Nationality, Race, and Tutor Mediums dropdowns. The dropdown now renders a consistent white custom overlay on all devices.

---

### TM-1166 — Home Page: Logout in Mobile Navigation Executes Without Confirmation

**Problem:** Tapping Logout in the mobile drawer menu immediately called `logout()` without any confirmation dialog. The desktop profile dropdown correctly shows a confirmation alert before logging out.

**Fix:** Added `ConfirmationAlert` to the drawer component with a `isLogoutConfirmationOpen` state gate. The Logout button now opens the confirmation dialog instead of logging out directly. On confirm, it calls `logout()` and closes both the dialog and the drawer. Uses the same translation keys (`nav.logout`, `nav.logoutConfirmation`, `nav.cancel`) as the desktop flow.

---

### UI — Past Exam Papers Page: Heading & Description Improvements

- Heading reduced from `text-4xl` to `text-3xl` to match FAQ and Register as Tutor pages
- Description changed from `text-xl` to `text-sm md:text-base` for mobile consistency
- Added `px-4 sm:px-0` to description to prevent edge-to-edge text on mobile
- Outer container changed from `py-10` to `pb-6 sm:py-10` to reduce top padding on mobile
- Updated `pastExamPapers.pageSubheading` in `messages/en.json` with more descriptive SEO-friendly copy covering Grade 1–13, Scholarship, O/L, A/L, model papers, and mediums

---

### UI — Tuition Rates Page: Mobile Container Padding

- Replaced `m-10` (40px all-side margin) on the outer wrapper with `px-4 lg:px-8`, matching the standard container pattern used by all home page sections (`AboutUs`, `Beliefs`, etc.)
- Removed redundant `m-3` from the inner `max-w-7xl` wrapper

## Test Plan

- [ ] TM-1163: Select multiple grades on tutor profile → subjects from all selected grades appear in the subjects dropdown
- [ ] TM-1163: Deselecting a grade removes its subjects from the list; previously selected subjects that no longer apply are cleared
- [ ] TM-1164: Open Register as Tutor on a ≤375px mobile viewport → Years of Experience stepper shows − on far left, number centred, + on far right with no overflow
- [ ] TM-1165: Open Register as Tutor → Certificates & Documents → tap Document Type → dropdown renders white background on mobile (iOS and Android)
- [ ] TM-1165: Selecting a document type works correctly and validates on form submit
- [ ] TM-1166: Open mobile drawer menu → tap Logout → confirmation dialog appears → Cancel keeps session, Confirm logs out and closes drawer
- [ ] TM-1166: Desktop profile dropdown logout confirmation still works unchanged
- [ ] Past Exam Papers: heading and description font sizes match FAQ page on mobile and desktop
- [ ] Tuition Rates: mobile view no longer has excessive horizontal margin; content aligns with home page sections