### PR TITLE
Fix multi-step form validation, navigation & dropdown consistency across tutor forms

### DIFF
--- a/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
@@ -288,6 +288,20 @@ const FormEducationInfo: FC<Props> = ({
   const subjectsLabel = t("fieldSubjects");
   const { isDirty, isValid } = form.formState;
 
+  // Run validation whenever a multi-select changes (including when the user
+  // removes the last value) so the "<field> is required" message appears
+  // immediately. MultiSelect never fires onBlur, so the form's "onTouched"
+  // mode would otherwise never re-validate these fields on deselect.
+  const handleMultiSelectChange =
+    (fieldName: string, onChange: (selected: string[]) => void) =>
+    (value: string[]) => {
+      onChange(value);
+      form.trigger(fieldName);
+    };
+
+  const fieldErrorMessage = (fieldName: string) =>
+    (form.formState.errors[fieldName]?.message as string | undefined) ?? "";
+
   const {
     fields: eduFields,
     append: appendEdu,
@@ -388,13 +402,24 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={classTypeOptions}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "classType",
+                        field.onChange,
+                      )}
                       hasError={!!fieldState.error}
                       placeholder={tR("classTypePlaceholder")}
                     />
                   )}
                 />
-                <span className="min-h-4 text-xs text-gray-500"></span>
+                <span
+                  className={`min-h-4 text-xs ${
+                    fieldErrorMessage("classType")
+                      ? "text-red-500"
+                      : "text-gray-500"
+                  }`}
+                >
+                  {fieldErrorMessage("classType")}
+                </span>
               </div>
 
               {/* Preferred Locations */}
@@ -412,7 +437,10 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={PREFERRED_LOCATION_OPTIONS}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "preferredLocations",
+                        field.onChange,
+                      )}
                       disabled={!isPreferredLocationsEnabled}
                       hasError={
                         isPreferredLocationsEnabled &&
@@ -450,13 +478,24 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={tutorTypeOptions}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "tutorTypes",
+                        field.onChange,
+                      )}
                       hasError={!!fieldState.error}
                       placeholder={tR("tutorTypesPlaceholder")}
                     />
                   )}
                 />
-                <span className="min-h-4 text-xs text-gray-500"></span>
+                <span
+                  className={`min-h-4 text-xs ${
+                    fieldErrorMessage("tutorTypes")
+                      ? "text-red-500"
+                      : "text-gray-500"
+                  }`}
+                >
+                  {fieldErrorMessage("tutorTypes")}
+                </span>
               </div>
 
               {/* Highest Education Level */}
@@ -493,13 +532,24 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={mediumOptions}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "tutorMediums",
+                        field.onChange,
+                      )}
                       hasError={!!fieldState.error}
                       placeholder={tR("tutorMediumsPlaceholder")}
                     />
                   )}
                 />
-                <span className="min-h-4 text-xs text-gray-500"></span>
+                <span
+                  className={`min-h-4 text-xs ${
+                    fieldErrorMessage("tutorMediums")
+                      ? "text-red-500"
+                      : "text-gray-500"
+                  }`}
+                >
+                  {fieldErrorMessage("tutorMediums")}
+                </span>
               </div>
 
               {/* Grades */}
@@ -514,13 +564,24 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={msOptions(gradesOptions)}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "grades",
+                        field.onChange,
+                      )}
                       hasError={!!fieldState.error}
                       placeholder={tR("gradesPlaceholder")}
                     />
                   )}
                 />
-                <span className="min-h-4 text-xs text-gray-500"></span>
+                <span
+                  className={`min-h-4 text-xs ${
+                    fieldErrorMessage("grades")
+                      ? "text-red-500"
+                      : "text-gray-500"
+                  }`}
+                >
+                  {fieldErrorMessage("grades")}
+                </span>
               </div>
 
               {/* Subjects */}
@@ -535,7 +596,10 @@ const FormEducationInfo: FC<Props> = ({
                     <MultiSelect
                       options={msOptions(subjectsOptions)}
                       defaultSelected={field.value ?? []}
-                      onChange={field.onChange}
+                      onChange={handleMultiSelectChange(
+                        "subjects",
+                        field.onChange,
+                      )}
                       hasError={!!fieldState.error}
                       disabled={isEmpty(selectedGrades)}
                       placeholder={tR("subjectsPlaceholder")}

--- a/src/app/[locale]/profile/[id]/components/form-language-time/availability-scheduler.tsx
+++ b/src/app/[locale]/profile/[id]/components/form-language-time/availability-scheduler.tsx
@@ -20,6 +20,7 @@ import {
   serializeAvailabilitySlots,
 } from "./availability";
 import { WEEK_DAY_OPTIONS } from "@/configs/options";
+import MultiSelect from "@/components/shared/MultiSelect";
 
 type TimePickerId = "start" | "end";
 type TimePeriod = "AM" | "PM";
@@ -456,6 +457,15 @@ const AvailabilityScheduler = () => {
     [t],
   );
 
+  const dayOptions = useMemo(
+    () =>
+      WEEK_DAY_OPTIONS.map((day) => ({
+        value: day.value,
+        text: dayFullMap[day.value] ?? day.value,
+      })),
+    [dayFullMap],
+  );
+
   const groupedSlots = useMemo(
     () =>
       WEEK_DAY_OPTIONS.map((day) => ({
@@ -553,22 +563,20 @@ const AvailabilityScheduler = () => {
 
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
               <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
-                <label className="flex flex-col">
+                <div className="flex flex-col">
                   <span className="mb-1 block text-xs font-medium text-gray-500">
                     {t("schedulerDay")}
                   </span>
-                  <select
-                    value={selectedDay}
-                    onChange={(event) => setSelectedDay(event.target.value)}
-                    className="h-12 rounded-md border border-linegrey px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                  >
-                    {WEEK_DAY_OPTIONS.map((day) => (
-                      <option key={day.value} value={day.value}>
-                        {dayFullMap[day.value] ?? day.value}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                  <MultiSelect
+                    options={dayOptions}
+                    defaultSelected={[selectedDay]}
+                    onChange={(selected) =>
+                      setSelectedDay(selected[0] ?? selectedDay)
+                    }
+                    singleSelect
+                    placeholder={t("schedulerDay")}
+                  />
+                </div>
 
                 <AlarmTimePicker
                   id="start"

--- a/src/app/[locale]/register-tutor/components/AcademicExperience.tsx
+++ b/src/app/[locale]/register-tutor/components/AcademicExperience.tsx
@@ -15,7 +15,7 @@ import {
   useFetchGradesQuery,
   useFetchSubjectsForGradesMutation,
 } from "@/store/api/splits/grades";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslateItems } from "@/hooks/useTranslateItems";
 
 /** Shared style tokens – keep in sync with other register-tutor components */
@@ -35,6 +35,7 @@ const AcademicExperience = () => {
     watch,
     setValue,
     getValues,
+    setError,
     clearErrors,
     formState: { errors },
   } = useFormContext();
@@ -52,6 +53,35 @@ const AcademicExperience = () => {
       selectedClassTypes.some(isPhysicalClassType)
     );
   }, [selectedClassTypes]);
+  // Each selectable grade already carries its subjects (the grade dropdown is
+  // built from this same data), so derive everything synchronously — no extra
+  // fetch, no races, and every selected grade is guaranteed to be present.
+  const gradeById = useMemo(() => {
+    const map = new Map<string, any>();
+    gradeData?.results?.forEach((g: any) => map.set(g.id, g));
+    return map;
+  }, [gradeData]);
+
+  // Subject IDs available for each selected grade. Derived synchronously from
+  // the nested grade data (reliable, no race) and used ONLY to validate that
+  // every selected grade has at least one selected subject — kept independent
+  // of how the dropdown options are loaded below.
+  const subjectsByGrade = useMemo<Record<string, string[]>>(() => {
+    const map: Record<string, string[]> = {};
+    selectedGradeIds.forEach((gradeId) => {
+      const grade = gradeById.get(gradeId);
+      map[gradeId] = (grade?.subjects ?? []).map((s: any) => s.id as string);
+    });
+    return map;
+  }, [selectedGradeIds, gradeById]);
+
+  // Latest validation map, readable inside the async loader without adding it
+  // as a dependency.
+  const subjectsByGradeRef = useRef(subjectsByGrade);
+  subjectsByGradeRef.current = subjectsByGrade;
+
+  // Dropdown subject options, loaded from the API for the selected grades
+  // (original behaviour — kept alongside the per-grade validation above).
   const [fetchSubjectsForGrades] = useFetchSubjectsForGradesMutation();
   const [subjectOptions, setSubjectOptions] = useState<OptionItem[]>([]);
   const classTypeOptions = useMemo(
@@ -150,6 +180,57 @@ const AcademicExperience = () => {
     }
   };
 
+  // Every selected grade that offers subjects must have at least one selected
+  // subject. Driven imperatively (not via a watch effect) so it reacts the
+  // instant the user picks/removes a subject — setting/clearing the error
+  // re-renders through the formState subscription, which is reliable.
+  const validateSubjectCoverage = useCallback(
+    (subjectIds: string[], gradeMap: Record<string, string[]>) => {
+      if (
+        selectedGradeIds.length === 0 ||
+        Object.keys(gradeMap).length === 0 ||
+        subjectIds.length === 0
+      ) {
+        return;
+      }
+
+      const selectedSet = new Set(subjectIds);
+      const hasGradeWithoutSubject = selectedGradeIds.some((gradeId) => {
+        const gradeSubjects = gradeMap[gradeId] ?? [];
+        return (
+          gradeSubjects.length > 0 &&
+          !gradeSubjects.some((id) => selectedSet.has(id))
+        );
+      });
+
+      if (hasGradeWithoutSubject) {
+        setError("subjects", {
+          type: "manual",
+          message: t("subjectPerGradeRequired"),
+        });
+      } else {
+        clearErrors("subjects");
+      }
+    },
+    [selectedGradeIds, setError, clearErrors, t],
+  );
+
+  // Subjects-specific change handler: update the value, then re-validate
+  // per-grade coverage immediately.
+  const handleSubjectsChange = (
+    onChange: MultiSelectOnChange,
+    selected: string[],
+  ) => {
+    onChange(selected);
+    if (selected.length === 0) {
+      // An empty selection is governed by the "subjects required" rule; drop
+      // any lingering per-grade error.
+      if (errors.subjects?.type === "manual") clearErrors("subjects");
+      return;
+    }
+    validateSubjectCoverage(selected, subjectsByGrade);
+  };
+
   useEffect(() => {
     if (isPreferredLocationsEnabled) return;
 
@@ -157,47 +238,66 @@ const AcademicExperience = () => {
     clearErrors("preferredLocations");
   }, [clearErrors, isPreferredLocationsEnabled, setValue]);
 
+  // Load the dropdown subject options for the selected grades from the API
+  // (original behaviour), prune any selected subjects that no longer belong to
+  // the current grades, then re-validate per-grade coverage against the nested
+  // map. Covers grade changes and tab remounts; live picks go through
+  // handleSubjectsChange.
   useEffect(() => {
     if (selectedGradeIds.length === 0) {
       setSubjectOptions([]);
       setValue("subjects", []);
+      clearErrors("subjects");
       return;
     }
+
+    let cancelled = false;
 
     const loadSubjects = async () => {
       try {
         const res = await fetchSubjectsForGrades({
           gradeIds: selectedGradeIds,
         }).unwrap();
+        if (cancelled) return;
 
         const newOptions = res.subjects.map((s: any) => ({
-          value: s.id,
-          text: s.title,
+          value: s.id as string,
+          text: s.title as string,
         }));
         setSubjectOptions(newOptions);
 
-        // Remove any previously selected subjects that no longer belong
-        // to the current set of grades.
         const validIds = new Set(newOptions.map((o) => o.value));
         const currentSubjects: string[] = getValues("subjects") ?? [];
         const filtered = currentSubjects.filter((id) => validIds.has(id));
-        setValue("subjects", filtered);
-        if (filtered.length > 0) {
+        if (filtered.length !== currentSubjects.length) {
+          setValue("subjects", filtered);
+        }
+        if (filtered.length === 0) {
+          // No subjects left — the "subjects required" rule governs; drop any
+          // stale per-grade error.
           clearErrors("subjects");
+        } else {
+          validateSubjectCoverage(filtered, subjectsByGradeRef.current);
         }
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to load subjects", error);
         setSubjectOptions([]);
       }
     };
 
     loadSubjects();
+
+    return () => {
+      cancelled = true;
+    };
   }, [
-    clearErrors,
     selectedGradeIds,
     fetchSubjectsForGrades,
-    setValue,
     getValues,
+    setValue,
+    clearErrors,
+    validateSubjectCoverage,
   ]);
 
   return (
@@ -411,7 +511,7 @@ const AcademicExperience = () => {
                 options={translatedSubjectOptions}
                 defaultSelected={field.value || []}
                 onChange={(selected) =>
-                  handleMultiSelectChange("subjects", field.onChange, selected)
+                  handleSubjectsChange(field.onChange, selected)
                 }
                 hasError={!!errors.subjects}
                 disabled={selectedGradeIds.length === 0}

--- a/src/app/[locale]/register-tutor/components/TutorTabs.tsx
+++ b/src/app/[locale]/register-tutor/components/TutorTabs.tsx
@@ -31,7 +31,10 @@ import TermsAndSubmit from "./TermsAndSubmit";
 import Stepper from "./Stepper";
 import { useTranslations, useLocale } from "next-intl";
 import { FindMyTutorForm, createFullSchema, STEP2_FIELDS } from "../schema";
-import { useAddTutorRequestMutation } from "@/store/api/splits/tutor-request";
+import {
+  useAddTutorRequestMutation,
+  useLazyValidateReferralCodeQuery,
+} from "@/store/api/splits/tutor-request";
 import { useFetchSubjectsForGradesMutation } from "@/store/api/splits/grades";
 import { getErrorInApiResult } from "@/utils/api";
 import { Spinner } from "@/components/ui/spinner";
@@ -53,6 +56,21 @@ const isDuplicateEmailError = (error: string) => {
   );
 };
 
+const isInvalidReferralError = (error: string) => {
+  const normalizedError = error.toLowerCase();
+  return (
+    (normalizedError.includes("referral") ||
+      normalizedError.includes("referred") ||
+      normalizedError.includes("referrer")) &&
+    (normalizedError.includes("invalid") ||
+      normalizedError.includes("not valid") ||
+      normalizedError.includes("not found") ||
+      normalizedError.includes("does not exist") ||
+      normalizedError.includes("doesn't exist") ||
+      normalizedError.includes("incorrect"))
+  );
+};
+
 export function TutorTabs() {
   const t = useTranslations("registerTutor");
   const locale = useLocale();
@@ -64,6 +82,7 @@ export function TutorTabs() {
   );
   const [addTutorRequest, { isLoading }] = useAddTutorRequestMutation();
   const [fetchSubjectsForGrades] = useFetchSubjectsForGradesMutation();
+  const [validateReferralCode] = useLazyValidateReferralCodeQuery();
   /** null = closed | "success" = success dialog | string = error message */
   const [submissionResult, setSubmissionResult] = useState<
     "success" | string | null
@@ -171,11 +190,13 @@ export function TutorTabs() {
     // Returning to an already-visited step surfaces its validation messages so
     // the user can see what's missing. First-time forward visits stay clean.
     if (revalidate && visitedTabs.has(nextTab)) {
-      // "subjects" is validated per-grade by the Qualifications step itself —
-      // a rule that isn't expressible in the Zod schema. Re-running the schema
-      // here would clear that manual error (subjects passes the schema's
-      // min(1) check), so exclude it and let AcademicExperience own it.
-      const fields = STEP_FIELDS[nextTab].filter((field) => field !== "subjects");
+      // "subjects" (per-grade coverage) and "referredByCode" (server-side
+      // existence check) are validated outside the Zod schema. Re-running the
+      // schema here would clear those manual errors (both pass their schema
+      // checks), so exclude them and let their own logic own them.
+      const fields = STEP_FIELDS[nextTab].filter(
+        (field) => field !== "subjects" && field !== "referredByCode",
+      );
       // Mark the fields touched so that, in onTouched mode, typing a valid value
       // re-validates and clears the message (otherwise it lingers until blur).
       fields.forEach((field) =>
@@ -216,6 +237,30 @@ export function TutorTabs() {
 
   const onSubmit = async (data: FindMyTutorForm) => {
     try {
+      // Validate the referral code (if any) up front so an invalid one is
+      // surfaced on its field — red highlight, assistive message and a jump
+      // back to Personal Information — instead of a generic submit error.
+      const referralCode = data.referredByCode?.trim().toUpperCase();
+      if (referralCode) {
+        try {
+          const referralResult =
+            await validateReferralCode(referralCode).unwrap();
+          if (referralResult && referralResult.valid === false) {
+            setError("referredByCode", {
+              type: "server",
+              message: t("referredByCodeInvalid"),
+            });
+            changeStep("personalInfo");
+            setTimeout(() => setFocus("referredByCode"), 0);
+            toast.error(t("referredByCodeInvalid"));
+            return;
+          }
+        } catch {
+          // Endpoint unavailable — let the submit endpoint validate it instead
+          // (handled by isInvalidReferralError below).
+        }
+      }
+
       // Each selected grade must have at least one matching subject selected.
       const selectedSubjectSet = new Set(data.subjects);
       const perGradeSubjectIds = await Promise.all(
@@ -280,6 +325,19 @@ export function TutorTabs() {
           changeStep("personalInfo");
           setTimeout(() => setFocus("email"), 0);
           toast.error(t("emailAlreadyExists"));
+          return;
+        }
+
+        // Invalid/non-existent referral code: highlight the field, jump back to
+        // Personal Information and focus it (mirrors the duplicate-email flow).
+        if (typeof error === "string" && isInvalidReferralError(error)) {
+          setError("referredByCode", {
+            type: "server",
+            message: t("referredByCodeInvalid"),
+          });
+          changeStep("personalInfo");
+          setTimeout(() => setFocus("referredByCode"), 0);
+          toast.error(t("referredByCodeInvalid"));
           return;
         }
 

--- a/src/app/[locale]/register-tutor/components/TutorTabs.tsx
+++ b/src/app/[locale]/register-tutor/components/TutorTabs.tsx
@@ -142,6 +142,13 @@ export function TutorTabs() {
       if (issue.path.length > 0) erroredFields.add(String(issue.path[0]));
     }
   }
+  // The per-grade subject rule lives outside the Zod schema (it needs the
+  // grade→subject mapping), so also fold any live form errors — e.g. the
+  // manual "subjects" error — into the step status so the stepper doesn't
+  // mark a step complete while one of its fields is actually invalid.
+  Object.keys(methods.formState.errors).forEach((field) =>
+    erroredFields.add(field),
+  );
 
   const stepHasError = (tabKey: TabKey) =>
     STEP_FIELDS[tabKey].some((field) => erroredFields.has(field));
@@ -152,16 +159,29 @@ export function TutorTabs() {
     { key: "verification", label: t("verification") },
   ].map((step) => ({ ...step, hasError: stepHasError(step.key as TabKey) }));
 
-  const changeStep = (nextTab: TabKey) => {
+  const changeStep = (
+    nextTab: TabKey,
+    options?: { revalidate?: boolean },
+  ) => {
+    // `revalidate` re-runs schema validation for the destination step. Skip it
+    // when the caller has already set a manual error that isn't part of the
+    // schema (e.g. the per-grade subject check), otherwise the re-validation
+    // would immediately clear that error before the user can see it.
+    const revalidate = options?.revalidate ?? true;
     // Returning to an already-visited step surfaces its validation messages so
     // the user can see what's missing. First-time forward visits stay clean.
-    if (visitedTabs.has(nextTab)) {
+    if (revalidate && visitedTabs.has(nextTab)) {
+      // "subjects" is validated per-grade by the Qualifications step itself —
+      // a rule that isn't expressible in the Zod schema. Re-running the schema
+      // here would clear that manual error (subjects passes the schema's
+      // min(1) check), so exclude it and let AcademicExperience own it.
+      const fields = STEP_FIELDS[nextTab].filter((field) => field !== "subjects");
       // Mark the fields touched so that, in onTouched mode, typing a valid value
       // re-validates and clears the message (otherwise it lingers until blur).
-      STEP_FIELDS[nextTab].forEach((field) =>
+      fields.forEach((field) =>
         setValue(field as any, getValues(field as any), { shouldTouch: true }),
       );
-      trigger(STEP_FIELDS[nextTab] as any);
+      trigger(fields as any);
     }
     setVisitedTabs((prev) => new Set(prev).add(tab));
     setTab(nextTab);
@@ -216,7 +236,10 @@ export function TutorTabs() {
           type: "manual",
           message: t("subjectPerGradeRequired"),
         });
-        changeStep("qualifications");
+        // Navigate without re-validating so the manual error survives (the
+        // per-grade rule isn't part of the Zod schema).
+        changeStep("qualifications", { revalidate: false });
+        toast.error(t("subjectPerGradeRequired"));
         return;
       }
 
@@ -296,8 +319,15 @@ export function TutorTabs() {
   const agreeAssignmentInfo = methods.watch("agreeAssignmentInfo");
   const allDocsComplete =
     certificates?.length > 0 && certificates.every((c) => c.type && c.url);
+  // Block submission while any step still has an error — including the
+  // per-grade subjects error, which isn't part of the Zod schema.
+  const hasStepErrors = steps.some((step) => step.hasError);
   const isSubmitDisabled =
-    isLoading || !allDocsComplete || !agreeTerms || !agreeAssignmentInfo;
+    isLoading ||
+    !allDocsComplete ||
+    !agreeTerms ||
+    !agreeAssignmentInfo ||
+    hasStepErrors;
 
   return (
     <FormProvider {...methods}>

--- a/src/app/[locale]/request-for-tutors/create-request/page.tsx
+++ b/src/app/[locale]/request-for-tutors/create-request/page.tsx
@@ -89,6 +89,7 @@ export default function AddRequestForTutor() {
     setValue,
     getValues,
     trigger,
+    setError,
     clearErrors,
     formState: { errors },
     reset,
@@ -267,29 +268,47 @@ export default function AddRequestForTutor() {
     tutors.forEach((_, i) => setValue(`tutors.${i}.subject`, ""));
   }, [selectedGradeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const nextStep = async () => {
-    if (tab === "contact") {
-      const valid = await trigger([
-        "name",
-        "email",
-        "phoneNumber",
-        "district",
-        "city",
-      ]);
-      if (!valid) return;
-    }
-    setVisitedTabs((prev) => new Set(prev).add(tab));
-    changeStep(TAB_ORDER[currentIndex + 1]);
-  };
+  // Mirrors the Register-as-a-Tutor form: advancing always works; an incomplete
+  // step surfaces a warning toast and inline validation messages rather than
+  // silently blocking navigation.
+  const nextStep = () => goForward(TAB_ORDER[currentIndex + 1]);
 
   const prevStep = () => changeStep(TAB_ORDER[currentIndex - 1]);
 
+  const getFieldTab = (field: string): TabKey =>
+    STEP_FIELDS.contact.includes(field) ? "contact" : "tutorDetails";
+
+  /** On a failed submit, jump to the earliest step that has an error. */
+  const onInvalid = (formErrors: Record<string, unknown>) => {
+    const erroredTabs = new Set(Object.keys(formErrors).map(getFieldTab));
+    const target = TAB_ORDER.find((tabKey) => erroredTabs.has(tabKey));
+    if (target) changeStep(target);
+  };
+
   const onSubmit = async (data: CreateRequestTutorSchema) => {
     try {
+      // The /v1/requestTutor endpoint expects the flat form values plus a
+      // status. (Field names/enums already match the backend's Joi schema.)
       const payload = { ...data, status: "Pending" };
+
       const result = await createTutorRequest(payload);
       const error = getErrorInApiResult(result);
       if (error) {
+        // The backend validates the email more strictly than the client — its
+        // Joi .email() rejects unknown TLDs (e.g. ".mjk") that pass on the
+        // client. Surface that on the field instead of a generic dialog, and
+        // navigate without re-validating so the manual error isn't cleared.
+        if (typeof error === "string" && /e-?mail/i.test(error)) {
+          setError("email", {
+            type: "server",
+            message: t("emailInvalid"),
+          });
+          setVisitedTabs((prev) => new Set(prev).add(tab));
+          setTab("contact");
+          window.scrollTo({ top: 0, behavior: "smooth" });
+          toast.error(t("emailInvalid"));
+          return;
+        }
         setSubmissionResult(error);
         return;
       }
@@ -328,7 +347,7 @@ export default function AddRequestForTutor() {
         }
       />
 
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
         <Tabs value={tab} className="w-full">
           {/* ── STEP 1: Contact Details ── */}
           <TabsContent value="contact">
@@ -903,8 +922,11 @@ export default function AddRequestForTutor() {
             <DialogTitle className="text-center text-xl font-semibold">
               {t("errorTitle")}
             </DialogTitle>
-            <DialogDescription className="text-center text-base">
-              {t("errorDesc")}
+            <DialogDescription className="text-center text-base whitespace-pre-line">
+              {typeof submissionResult === "string" &&
+              submissionResult !== "success"
+                ? submissionResult
+                : t("errorDesc")}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="justify-center mt-2">

--- a/src/app/[locale]/request-for-tutors/create-request/schema.ts
+++ b/src/app/[locale]/request-for-tutors/create-request/schema.ts
@@ -4,6 +4,7 @@ import {
   removeWhitespace,
   trimText,
 } from "@/utils/form-normalizers";
+import { hasValidEmailTld } from "@/utils/email-validation";
 
 export const createRequestTutorSchema = (t: (_key: string) => string) =>
   z.object({
@@ -17,7 +18,14 @@ export const createRequestTutorSchema = (t: (_key: string) => string) =>
 
     email: z.preprocess(
       removeWhitespace,
-      z.string().min(1, t("emailRequired")).email(t("emailInvalid")),
+      z
+        .string()
+        .min(1, t("emailRequired"))
+        .email(t("emailInvalid"))
+        // Reject unknown TLDs (e.g. ".mjk") the way the backend's Joi does,
+        // so an invalid email is flagged inline as the user types instead of
+        // only failing on submit.
+        .refine((value) => hasValidEmailTld(value), t("emailInvalid")),
     ),
 
     city: z.preprocess(trimText, z.string().min(1, t("cityRequired"))),

--- a/src/utils/email-validation.ts
+++ b/src/utils/email-validation.ts
@@ -8,6 +8,40 @@ const providerDomains: Record<string, string[]> = {
   icloud: ["icloud.com"],
 };
 
+// Generic TLDs the backend (Joi's IANA-backed `.email()`) accepts. Any
+// two-letter TLD is treated as a country code. Longer TLDs must be in this
+// list, so obvious fakes like ".mjk" are rejected on the client too. The
+// server remains the source of truth — this just catches the common cases.
+const COMMON_GENERIC_TLDS = new Set([
+  "com", "org", "net", "edu", "gov", "mil", "int", "arpa", "info", "biz",
+  "name", "pro", "aero", "asia", "cat", "coop", "jobs", "mobi", "museum",
+  "post", "tel", "travel", "xxx", "io", "co", "ai", "app", "dev", "xyz",
+  "online", "site", "tech", "store", "blog", "cloud", "email", "live", "tv",
+  "cc", "ws", "fm", "me", "ly", "ngo", "ong", "one", "plus", "vip", "wiki",
+  "academy", "agency", "business", "capital", "care", "careers", "center",
+  "city", "club", "community", "company", "consulting", "design", "digital",
+  "directory", "education", "events", "expert", "finance", "fund", "global",
+  "group", "guru", "health", "help", "host", "institute", "international",
+  "life", "ltd", "management", "marketing", "media", "network", "news",
+  "ninja", "partners", "photography", "press", "productions", "school",
+  "services", "shop", "social", "solutions", "space", "studio", "systems",
+  "team", "today", "tools", "training", "ventures", "website", "work",
+  "works", "world", "zone", "page", "games", "gold", "green", "money", "fit",
+  "fun", "run", "sport", "studio",
+]);
+
+/**
+ * Returns true when the email's TLD looks valid (a 2-letter country code or a
+ * known generic TLD). Mirrors the backend's Joi `.email()` TLD validation so
+ * invalid TLDs (e.g. "name@host.mjk") are flagged on the client too.
+ */
+export const hasValidEmailTld = (email: string) => {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return false;
+  const tld = email.split(".").pop()?.toLowerCase() ?? "";
+  if (/^[a-z]{2}$/.test(tld)) return true;
+  return COMMON_GENERIC_TLDS.has(tld);
+};
+
 export const getEmailFormatError = (email: string) => {
   if (!emailPattern.test(email)) {
     return "Please enter a valid email address";


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does and why -->
Fixes a batch of related bugs across the Tutor Profile, Register-as-a-Tutor, and Request-for-Tutor forms. Mandatory multi-selects now show validation messages when emptied, per-grade subject coverage is validated reactively, the Weekly Availability day picker uses the shared white dropdown on mobile, the Request-for-Tutor "Next" button advances correctly, and invalid emails (bad TLDs) are caught inline instead of failing silently on submit.

## Changes

### Frontend
<!-- List frontend changes, or write "No frontend changes in this PR" -->
* **Profile → Qualifications:** mandatory multi-selects (Class Type, Tutor Types, Tutor Mediums, Grades, Subjects) now trigger validation on change and render the "<field> is required" message + red highlight when all options are removed.
* **Register-as-a-Tutor → per-grade subjects:** reactive validation derived from the nested grade data — every selected grade that offers subjects must have at least one selected subject; the message appears immediately on pick/remove, the step shows a red ✗, and Submit is disabled while the error is present.
* **Register-as-a-Tutor → referral code:** invalid/non-existent codes are surfaced on the field (red + assistive message); on submit the form jumps back to Personal Information and focuses the field; navigation no longer clears the manual error.
* **Profile → Languages, Availability & Rate:** replaced the native `<select>` day picker with the shared `MultiSelect` (singleSelect) so the dropdown is white/consistent on mobile instead of the OS-dark picker.
* **Request-for-Tutor:** "Next" now always advances (with inline errors + warning toast) consistent with Register-as-a-Tutor; added `onInvalid` to jump to the offending step on submit; error dialog now shows the real backend message; invalid email is routed to the field.
* **Email validation:** added `hasValidEmailTld()` and a Zod `.refine()` on the Request-for-Tutor email field to reject unknown TLDs (e.g. `.mjk`) inline, mirroring the backend's Joi `.email()` check.
* Added `Stepper` component to the Request-for-Tutor form and step-error tracking.
* Added/updated i18n strings (en/si/ta) for the new validation messages.

### Backend
<!-- List backend changes, or write "No backend changes in this PR" -->
* No backend changes in this PR.

## Files Changed
<!-- List all modified files -->
* src/app/[locale]/profile/[id]/components/form-education-information/index.tsx
* src/app/[locale]/profile/[id]/components/form-language-time/availability-scheduler.tsx
* src/app/[locale]/register-tutor/components/AcademicExperience.tsx
* src/app/[locale]/register-tutor/components/TutorTabs.tsx
* src/app/[locale]/request-for-tutors/create-request/page.tsx
* src/app/[locale]/request-for-tutors/create-request/schema.ts
* src/app/[locale]/request-for-tutors/create-request/Stepper.tsx
* src/utils/email-validation.ts
* messages/en.json
* messages/si.json
* messages/ta.json

## Root Cause
<!-- What caused the issue? (for bug fixes) or N/A for features -->
* **Multi-select messages:** fields rendered empty placeholder spans and, in `onTouched` mode, never re-validated because `MultiSelect` never fires `onBlur`.
* **Per-grade subjects:** the rule lived only in `onSubmit` as a one-shot `setError`, which was repeatedly cleared by `changeStep`'s `trigger`, the tab remount, and `handleSubmit` re-validation — and earlier used fragile concurrent per-grade fetches. Reworked to derive coverage synchronously from the already-loaded nested grade data.
* **Day dropdown dark on mobile:** used a native `<select>`, which defers to the OS (dark-mode) picker.
* **Request-for-Tutor "Next":** `nextStep` hard-blocked on `trigger()` and never advanced; submit had no `onInvalid`.
* **Submission "Something went wrong":** the dialog hardcoded a generic message, hiding the real error; the actual 400 was the backend's Joi `.email()` rejecting an unknown TLD (`.mjk`) that the client's `.email()` accepted.

## Result
<!-- What does the user/system experience after this PR? -->
* Emptying a mandatory multi-select immediately shows a red "<field> is required" message.
* Leaving a grade without a subject shows "Please select at least one subject for each selected grade." instantly, flags the step, and blocks Submit until fixed.
* Invalid referral codes are highlighted on the field with navigation + focus back to Personal Information.
* The Weekly Availability day dropdown is white and consistent on mobile.
* The Request-for-Tutor "Next" button advances reliably with clear validation feedback, matching Register-as-a-Tutor.
* Invalid emails (bad TLDs) are flagged inline as the user fills the field instead of a generic submit failure; valid submissions go through.

## Checklist
* [ ] Self-reviewed code
* [ ] Tested locally
* [ ] No unrelated changes included
* [ ] Relevant tickets updated